### PR TITLE
Disable macOS builds on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,18 +34,21 @@ matrix:
     compiler: ": #stack 8.2.2"
     addons: {apt: {packages: [libgmp-dev]}}
 
-  # Build on macOS in addition to Linux
-  - env: BUILD=stack ARGS=""
-    compiler: ": #stack default osx"
-    os: osx
+  # macOS builds on Travis CI are slow and backlogged:
+  # https://www.traviscistatus.com/incidents/6xb4kjczh4k6 Disable for now.
 
-  - env: BUILD=stack ARGS="--resolver lts-9"
-    compiler: ": #stack 8.0.2 osx"
-    os: osx
+  # # Build on macOS in addition to Linux
+  # - env: BUILD=stack ARGS=""
+  #   compiler: ": #stack default osx"
+  #   os: osx
 
-  - env: BUILD=stack ARGS="--resolver lts-10"
-    compiler: ": #stack 8.2.2 osx"
-    os: osx
+  # - env: BUILD=stack ARGS="--resolver lts-9"
+  #   compiler: ": #stack 8.0.2 osx"
+  #   os: osx
+
+  # - env: BUILD=stack ARGS="--resolver lts-10"
+  #   compiler: ": #stack 8.2.2 osx"
+  #   os: osx
 
 before_install:
 # Using compiler above sets CC to an invalid value, so unset it


### PR DESCRIPTION
macOS builds on Travis CI are slow and backlogged:
https://www.traviscistatus.com/incidents/6xb4kjczh4k6 Disable for now.