### PR TITLE
Disable excluding Node dependencies

### DIFF
--- a/serverless-plugin/index.js
+++ b/serverless-plugin/index.js
@@ -49,7 +49,11 @@ class ServerlessPlugin {
             haveImage: false,
         };
 
-        // Do not try to look into Node dependencies
+        // By default, Serverless examines node_modules to figure out which
+        // packages there are from dependencies versus devDependencies of a
+        // package. While there will always be a node_modules due to Serverless
+        // and this plugin being installed, it will be excluded anyway.
+        // Therefore, the filtering can be disabled to speed up the process.
         this.serverless.service.package.excludeDevDependencies = false;
 
         this.additionalFiles = [];

--- a/serverless-plugin/index.js
+++ b/serverless-plugin/index.js
@@ -49,6 +49,9 @@ class ServerlessPlugin {
             haveImage: false,
         };
 
+        // Do not try to look into Node dependencies
+        this.serverless.service.package.excludeDevDependencies = false;
+
         this.additionalFiles = [];
     }
 


### PR DESCRIPTION
No Node dependencies are present in the uploaded files anyway, and calculating
which ones are for development only takes time.