### PR TITLE
Disable nix when enabling docker

### DIFF
--- a/serverless-plugin/index.js
+++ b/serverless-plugin/index.js
@@ -72,6 +72,7 @@ class ServerlessPlugin {
                 this.docker.haveImage = true;
             }
             dockerArgs.push('--docker');
+            dockerArgs.push('--no-nix');
         }
         return spawnSync(
             'stack',


### PR DESCRIPTION
I had `--nix` set in my user config file. It doesn't play well with `--docker` and causes the script to fail in fairly inscrutable ways. I'm fairly confident that it's correct to always turn off `nix` when turning on `docker` because calling `stack` with both produces error messages like:
```
Executable named nix-shell not found on path: [/opt/host/bin,/home/.../code/serverless-test/.stack-work/docker/_home/.local/bin,/root/.cabal/bin,/root/.local/bin,/opt/ghc/8.2.2/bin,/usr/local/sbin,/usr/local/bin,/usr/sbin,/usr/bin,/sbin,/bin]
```
which is very wrong for NixOS.