### PR TITLE
Support serverless-offline and invoke local

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Deploying Haskell code onto [AWS Lambda] using [Serverless].
   You can test the function and see the invocation results with `sls invoke
   myfunc`.
 
+  To invoke the function locally, use `sls invoke local -f myfunc`.
+
 ### Notes
 
 * `sls deploy function` is [not supported yet](https://github.com/seek-oss/serverless-haskell/issues/20).

--- a/README.md
+++ b/README.md
@@ -85,6 +85,15 @@ Deploying Haskell code onto [AWS Lambda] using [Serverless].
 
   To invoke the function locally, use `sls invoke local -f myfunc`.
 
+### API Gateway
+
+This plugin supports handling API Gateway requests. Declare the HTTP events
+normally in `serverless.yml` and use
+[AWSLambda.Events.APIGateway](https://hackage.haskell.org/package/serverless-haskell/docs/AWSLambda-Events-APIGateway.html)
+in the handler to process them.
+
+[Serverless Offline] can be used for local testing of API Gateway requests.
+
 ### Notes
 
 * `sls deploy function` is [not supported yet](https://github.com/seek-oss/serverless-haskell/issues/20).
@@ -129,4 +138,5 @@ series, use `RESOLVER_SERIES=lts-9`.
 [jq]: https://stedolan.github.io/jq/
 [NPM]: https://www.npmjs.com/
 [Serverless]: https://serverless.com/framework/
+[Serverless Offline]: https://github.com/dherault/serverless-offline
 [Stack]: https://haskellstack.org

--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ Deploying Haskell code onto [AWS Lambda] using [Serverless].
 ### Notes
 
 * `sls deploy function` is [not supported yet](https://github.com/seek-oss/serverless-haskell/issues/20).
-* `sls invoke local` is [not supported yet](https://github.com/seek-oss/serverless-haskell/issues/32).
 * Only AWS Lambda is supported at the moment. Other cloud providers would
   require different JavaScript wrappers to be implemented.
 

--- a/example-project/package.json
+++ b/example-project/package.json
@@ -6,7 +6,7 @@
     "test": "test"
   },
   "dependencies": {
-    "serverless": "^1.26.0",
+    "serverless": "^1.27.3",
     "serverless-haskell": "file:../serverless-plugin"
   },
   "devDependencies": {},

--- a/integration-test/expected/local_output.txt
+++ b/integration-test/expected/local_output.txt
@@ -1,0 +1,9 @@
+This should go to logs
+["one","two","--three"]
+Just ["abc"]
+Array [Number 4.0,Number 5.0,Number 6.0]
+[
+    1,
+    2,
+    3
+]

--- a/integration-test/expected/offline_output.txt
+++ b/integration-test/expected/offline_output.txt
@@ -1,0 +1,1 @@
+Hello, integration

--- a/integration-test/run.sh
+++ b/integration-test/run.sh
@@ -80,20 +80,32 @@ done
 
 export PATH=$(npm bin):$PATH
 
-# Install Serverless and deploy the project
+# Install Serverless
 npm install serverless
 npm install $DIST/serverless-plugin
+npm install serverless-offline
 
+# Just package the service first
+sls package
+echo "Packaging verified."
+
+# Test local invocation
 sls invoke local --function main --data '[4, 5, 6]' | \
     grep -v 'Serverless: ' > local_output.txt
 
 diff $EXPECTED/local_output.txt local_output.txt && echo "Expected local result verified."
 
+# Test serverless-offline
+sls offline start --exec \
+    "sh -c 'curl -s http://localhost:3000/hello/integration > offline_output.txt'"
+diff $EXPECTED/offline_output.txt offline_output.txt && echo "Expected serverless-offline result verified."
+
 if [ "$DRY_RUN" = "true" ]
 then
-    sls package
-    echo "Packaging verified."
+    # All done (locally)
+    exit 0
 else
+    # Deploy to AWS
     sls deploy
 
     # Run the function and verify the results

--- a/integration-test/run.sh
+++ b/integration-test/run.sh
@@ -84,6 +84,11 @@ export PATH=$(npm bin):$PATH
 npm install serverless
 npm install $DIST/serverless-plugin
 
+sls invoke local --function main --data '[4, 5, 6]' | \
+    grep -v 'Serverless: ' > local_output.txt
+
+diff $EXPECTED/local_output.txt local_output.txt && echo "Expected local result verified."
+
 if [ "$DRY_RUN" = "true" ]
 then
     sls package

--- a/integration-test/skeleton/ApiGateway.hs
+++ b/integration-test/skeleton/ApiGateway.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main where
+
+import AWSLambda.Events.APIGateway
+import Control.Lens
+import qualified Data.HashMap.Strict as HashMap
+import Data.Semigroup
+import Data.Text (Text)
+
+main :: IO ()
+main = apiGatewayMain hello
+
+hello :: APIGatewayProxyRequest Text -> IO (APIGatewayProxyResponse Text)
+hello request = do
+  putStrLn "This should go to logs"
+  case HashMap.lookup "name" (request ^. agprqPathParameters) of
+    Just name -> return $ responseOK & responseBody ?~ "Hello, " <> name <> "\n"
+    Nothing -> return responseNotFound

--- a/integration-test/skeleton/package.yaml
+++ b/integration-test/skeleton/package.yaml
@@ -14,3 +14,14 @@ executables:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
+
+  apigw:
+    main: ApiGateway.hs
+    ghc-options:
+    - -threaded
+    - -rtsopts
+    - -with-rtsopts=-N
+    dependencies:
+      - lens
+      - text
+      - unordered-containers

--- a/integration-test/skeleton/serverless.yml
+++ b/integration-test/skeleton/serverless.yml
@@ -8,11 +8,19 @@ functions:
   main:
     handler: shtest.main
 
+  apigw:
+    handler: shtest.apigw
+    events:
+      - http:
+          path: hello/{name}
+          method: get
+
   subdir:
     handler: subdir/subtest.main
 
 plugins:
 - serverless-haskell
+- serverless-offline
 
 custom:
   haskell:

--- a/serverless-plugin/index.js
+++ b/serverless-plugin/index.js
@@ -34,6 +34,8 @@ class ServerlessPlugin {
         this.hooks = {
             'before:package:createDeploymentArtifacts': this.beforeCreateDeploymentArtifacts.bind(this),
             'after:package:createDeploymentArtifacts': this.afterCreateDeploymentArtifacts.bind(this),
+            // serverless-offline
+            'before:offline:start:init': this.beforeCreateDeploymentArtifacts.bind(this),
         };
 
         this.servicePath = this.serverless.config.servicePath || '';

--- a/serverless-plugin/index.js
+++ b/serverless-plugin/index.js
@@ -34,6 +34,10 @@ class ServerlessPlugin {
         this.hooks = {
             'before:package:createDeploymentArtifacts': this.beforeCreateDeploymentArtifacts.bind(this),
             'after:package:createDeploymentArtifacts': this.afterCreateDeploymentArtifacts.bind(this),
+
+            // invoke local
+            'before:invoke:local:invoke': this.beforeCreateDeploymentArtifacts.bind(this),
+            'after:invoke:local:invoke': this.afterCreateDeploymentArtifacts.bind(this),
             // serverless-offline
             'before:offline:start:init': this.beforeCreateDeploymentArtifacts.bind(this),
         };

--- a/serverless-plugin/package-lock.json
+++ b/serverless-plugin/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-haskell",
-  "version": "0.4.3",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -179,11 +179,18 @@
       },
       "dependencies": {
         "async": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "requires": {
-            "lodash": "^4.14.0"
+            "lodash": "^4.17.10"
+          },
+          "dependencies": {
+            "lodash": {
+              "version": "4.17.10",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+              "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+            }
           }
         }
       }
@@ -202,9 +209,9 @@
       }
     },
     "are-we-there-yet": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "requires": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -248,9 +255,9 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-sdk": {
-      "version": "2.242.1",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.242.1.tgz",
-      "integrity": "sha1-yypdgbcLjf1kFraGrjj5wGEfCH0=",
+      "version": "2.256.1",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.256.1.tgz",
+      "integrity": "sha512-Z3RLtNBNKgKS6K0VKV8e8NvJFqgpkeZNF+3gudYdIfMzFSOmu0C2Y9oA7aZ40UjFLRoVMkh5BoDZ1dKOmdsxxg==",
       "requires": {
         "buffer": "4.9.1",
         "events": "1.1.1",
@@ -424,18 +431,18 @@
       }
     },
     "buffer-alloc": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.1.0.tgz",
-      "integrity": "sha1-BVFNM78WVtNUDGhPZbEgLpDsowM=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
       "requires": {
-        "buffer-alloc-unsafe": "^0.1.0",
-        "buffer-fill": "^0.1.0"
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
       }
     },
     "buffer-alloc-unsafe": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-0.1.1.tgz",
-      "integrity": "sha1-/+H2dVHdBVc33iUzN7/oU9+rGmo="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
     },
     "buffer-crc32": {
       "version": "0.2.13",
@@ -443,9 +450,9 @@
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
     },
     "buffer-fill": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-0.1.1.tgz",
-      "integrity": "sha512-YgBMBzdRLEfgxJIGu2wrvI2E03tMCFU1p7d1KhB4BOoMN0VxmTFjSyN5JtKt9z8Z9JajMHruI6SE25W96wNv7Q=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
     },
     "caller-path": {
       "version": "0.1.0",
@@ -627,9 +634,9 @@
       "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
     },
     "cookiejar": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.1.tgz",
-      "integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -763,9 +770,9 @@
       }
     },
     "deep-extend": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
-      "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -1168,9 +1175,9 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fd-slicer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "requires": {
         "pend": "~1.2.0"
       }
@@ -1912,9 +1919,9 @@
       }
     },
     "moment": {
-      "version": "2.22.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.1.tgz",
-      "integrity": "sha512-shJkRTSebXvsVqk56I+lkb2latjBs8I+pc2TzWc545y2iFnSjm7Wg0QMh+ZWcdSLQyGEau5jI8ocnmkyTgr9YQ=="
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
+      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
     },
     "ms": {
       "version": "2.0.0",
@@ -2018,7 +2025,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
     },
     "opn": {
@@ -2204,11 +2211,11 @@
       }
     },
     "rc": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
-      "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "requires": {
-        "deep-extend": "^0.5.1",
+        "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
         "minimist": "^1.2.0",
         "strip-json-comments": "~2.0.1"
@@ -2375,9 +2382,9 @@
       "integrity": "sha1-kqSWkGX5xwxpR1PVUkj8aPj2Usk="
     },
     "serverless": {
-      "version": "1.27.2",
-      "resolved": "https://registry.npmjs.org/serverless/-/serverless-1.27.2.tgz",
-      "integrity": "sha1-lA/ApGTPJdepFMYH2KuUELpYR5o=",
+      "version": "1.27.3",
+      "resolved": "https://registry.npmjs.org/serverless/-/serverless-1.27.3.tgz",
+      "integrity": "sha1-bN5fpSD9CZiGRgAz/xqt0oAMx7M=",
       "requires": {
         "@serverless/fdk": "^0.5.1",
         "apollo-client": "^1.9.2",
@@ -2835,9 +2842,9 @@
       },
       "dependencies": {
         "punycode": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
         }
       }
     },
@@ -2851,9 +2858,9 @@
       }
     },
     "url-parse": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.0.tgz",
-      "integrity": "sha512-ERuGxDiQ6Xw/agN4tuoCRbmwRuZP0cJ1lJxJubXr5Q/5cDa78+Dc4wfvtxzhzhkm5VvmW6Mf8EVj9SPGN4l8Lg==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.1.tgz",
+      "integrity": "sha512-x95Td74QcvICAA0+qERaVkRpTGKyBHHYdwL2LXZm5t/gBtCB9KQSO/0zQgSTYEV1p0WcvSg79TLNPSvd5IDJMQ==",
       "requires": {
         "querystringify": "^2.0.0",
         "requires-port": "^1.0.0"
@@ -3005,12 +3012,12 @@
       "integrity": "sha1-0A88+ddztyQUCa6SpnQNHbGfSeY="
     },
     "yauzl": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.1.tgz",
-      "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.2.tgz",
+      "integrity": "sha1-T7G8euH8L1cDe1SvasyP4QMcW3c=",
       "requires": {
         "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.0.1"
+        "fd-slicer": "~1.1.0"
       }
     },
     "zen-observable-ts": {

--- a/serverless-plugin/package.json
+++ b/serverless-plugin/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "fs-copy-file-sync": "^1.1.1",
     "fs-extra": "^5.0.0",
-    "serverless": "^1.27.2"
+    "serverless": "^1.27.3"
   },
   "devDependencies": {
     "eslint": "^4.19.1"

--- a/src/AWSLambda.hs
+++ b/src/AWSLambda.hs
@@ -1,5 +1,5 @@
 {-|
-Module      : AWSLambda.Handler
+Module      : AWSLambda
 Stability   : experimental
 Portability : POSIX
 
@@ -46,6 +46,15 @@ To deploy a Haskell function on AWS Lambda:
   myfunc@.
 
   To invoke the function locally, use @sls invoke local -f myfunc@.
+
+= API Gateway
+
+This plugin supports handling API Gateway requests. Declare the HTTP events
+normally in @serverless.yml@ and use 'AWSLambda.Events.APIGateway' in the
+handler to process them.
+
+<https://github.com/dherault/serverless-offline Serverless Offline> can be used
+for local testing of API Gateway requests.
 
 = Additional features
 

--- a/src/AWSLambda.hs
+++ b/src/AWSLambda.hs
@@ -45,6 +45,8 @@ To deploy a Haskell function on AWS Lambda:
   You can test the function and see the invocation results with @sls invoke
   myfunc@.
 
+  To invoke the function locally, use @sls invoke local -f myfunc@.
+
 = Additional features
 
 Configuration options are passed to the plugin under @haskell@ key in @custom@

--- a/src/AWSLambda/Events/APIGateway.hs
+++ b/src/AWSLambda/Events/APIGateway.hs
@@ -8,6 +8,19 @@ Module: AWSLambda.Events.APIGateway
 Description: Types for APIGateway Lambda requests and responses
 
 Based on https://github.com/aws/aws-lambda-dotnet/tree/master/Libraries/src/Amazon.Lambda.APIGatewayEvents
+
+To enable processing of API Gateway events, use the @events@ key in
+@serverless.yml@ as usual:
+
+> functions:
+>   myapifunc:
+>     handler: mypackage.mypackage-exe
+>     events:
+>       - http:
+>           path: hello/{name}
+>           method: get
+
+Then use 'apiGatewayMain' in the handler to process the requests.
 -}
 module AWSLambda.Events.APIGateway where
 
@@ -200,36 +213,36 @@ responseBodyEmbedded = responseBody . mapping unEmbed
 responseBodyBinary :: Setter' (APIGatewayProxyResponse Base64) (Maybe ByteString)
 responseBodyBinary = responseBody . mapping _Base64
 
--- | Process incoming events from @serverless-haskell@ using a provided
--- function.
---
--- This is a specialisation of lambdaMain for API Gateway.
---
--- The handler receives the input event given to the AWS Lambda function, and
--- its return value is returned from the function.
---
--- This is intended to be used as @main@, for example:
---
--- > import AWSLambda.Events.APIGateway
--- > import Control.Lens
--- > import Data.Aeson
--- > import Data.Aeson.Embedded
--- >
--- > main = apiGatewayMain handler
--- >
--- > handler :: APIGatewayProxyRequest (Embedded Value) -> IO (APIGatewayProxyResponse (Embedded [Int]))
--- > handler request = do
--- >   putStrLn "This should go to logs"
--- >   print $ request ^. requestBody
--- >   pure $ responseOK & responseBodyEmbedded ?~ [1, 2, 3]
---
--- The type parameters @reqBody@ and @resBody@ represent the types of request and response body, respectively.
--- The @FromText@ and @ToText@ contraints are required because these values come from string fields
--- in the request and response JSON objects.
--- To get direct access to the body string, use @Text@ as the parameter type.
--- To treat the body as a stringified embedded JSON value, use @Embedded a@, where @a@ has the
--- appropriate @FromJSON@ or @ToJSON@ instances.
--- To treat the body as base 64 encoded binary use @Base64@.
+{-| Process incoming events from @serverless-haskell@ using a provided function.
+
+This is a specialisation of 'lambdaMain' for API Gateway.
+
+The handler receives the input event given to the AWS Lambda function, and
+its return value is returned from the function.
+
+This is intended to be used as @main@, for example:
+
+> import AWSLambda.Events.APIGateway
+> import Control.Lens
+> import Data.Aeson
+> import Data.Aeson.Embedded
+>
+> main = apiGatewayMain handler
+>
+> handler :: APIGatewayProxyRequest (Embedded Value) -> IO (APIGatewayProxyResponse (Embedded [Int]))
+> handler request = do
+>   putStrLn "This should go to logs"
+>   print $ request ^. requestBody
+>   pure $ responseOK & responseBodyEmbedded ?~ [1, 2, 3]
+
+The type parameters @reqBody@ and @resBody@ represent the types of request and response body, respectively.
+The @FromText@ and @ToText@ contraints are required because these values come from string fields
+in the request and response JSON objects.
+To get direct access to the body string, use @Text@ as the parameter type.
+To treat the body as a stringified embedded JSON value, use @Embedded a@, where @a@ has the
+appropriate @FromJSON@ or @ToJSON@ instances.
+To treat the body as base 64 encoded binary use @Base64@.
+-}
 apiGatewayMain
   :: (FromText reqBody, ToText resBody)
   => (APIGatewayProxyRequest reqBody -> IO (APIGatewayProxyResponse resBody)) -- ^ Function to process the event

--- a/src/AWSLambda/Handler.hs
+++ b/src/AWSLambda/Handler.hs
@@ -6,6 +6,7 @@ Portability : POSIX
 Entry point for AWS Lambda handlers deployed with @serverless-haskell@ plugin.
 -}
 {-# LANGUAGE TypeApplications #-}
+
 module AWSLambda.Handler
   ( lambdaMain
   ) where
@@ -19,11 +20,12 @@ import qualified Data.ByteString as ByteString
 
 import qualified Data.Text.Lazy.IO as Text
 
-import GHC.IO.Handle (Handle, hClose)
+import GHC.IO.Handle
+       (BufferMode(..), Handle, hClose, hSetBuffering)
 
 import System.IO (stdout)
-import System.Posix.IO (fdToHandle)
 import System.Posix.Files (getFdStatus)
+import System.Posix.IO (fdToHandle)
 import System.Posix.Types (Fd(..))
 
 -- | Process incoming events from @serverless-haskell@ using a provided
@@ -89,14 +91,17 @@ lambdaMain act =
         Text.hPutStrLn resultChannel $ Aeson.encodeToLazyText result
         pure ()
 
--- | Invoke an action with the handle to write the results to. On AWS Lambda,
--- use the channel opened by the JavaScript wrapper, otherwise use standard
--- output.
+-- | Invoke an action with the handle to write the results to. If called by the
+-- JavaScript wrapper, use the channel opened by it, otherwise use standard
+-- output. Also set line buffering on standard output for AWS Lambda so the logs
+-- are output in a timely manner.
 withResultChannel :: (Handle -> IO r) -> IO r
 withResultChannel act = do
   commStatus <- try @IOError $ getFdStatus communicationFd
   case commStatus of
-    Right _ -> bracket (fdToHandle communicationFd) hClose act
+    Right _ -> do
+      hSetBuffering stdout LineBuffering
+      bracket (fdToHandle communicationFd) hClose act
     Left _ -> act stdout
 
 -- | File descriptor opened by the JavaScript wrapper to listen for the results


### PR DESCRIPTION
Turns out that using the same handlers as we're already uploading to AWS works perfectly for `sls invoke local` and `sls offline start` ([serverless-offline](https://github.com/dherault/serverless-offline/)). Just needed to remove the check on the AWS environment variable.

Fixes #32.
Fixes #48.

Currently blocked on https://github.com/dherault/serverless-offline/issues/436 (serverless-offline part, `invoke local` works).