### PR TITLE
Handle matching against multiple stack versions

### DIFF
--- a/serverless-plugin/index.js
+++ b/serverless-plugin/index.js
@@ -158,11 +158,12 @@ class ServerlessPlugin {
                 'dependencies',
             ]
         ).split("\n");
-        const haskellPackageVersion = stackDependencies.filter(dep => dep.startsWith(`${PACKAGE_NAME} `));
-        if (haskellPackageVersion.length === 0) {
-            this.serverless.cli.log(`Could not find ${PACKAGE_NAME} in stacks dependencies.`);
+        const haskellPackageVersions = stackDependencies.filter(dep => dep.startsWith(`${PACKAGE_NAME} `));
+        if (haskellPackageVersions.length === 0) {
+            this.serverless.cli.log(`Could not find ${PACKAGE_NAME} in stack's dependencies.`);
             throw new Error("Package not found.");
         }
+        const haskellPackageVersion = haskellPackageVersions[0].split(' ')[1];
 
         const javascriptPackageVersion = JSON.parse(spawnSync(
             'npm',
@@ -173,8 +174,8 @@ class ServerlessPlugin {
             ]
         ).stdout)['dependencies'][PACKAGE_NAME]['version'];
 
-        if (haskellPackageVersion[0] != `${PACKAGE_NAME} ${javascriptPackageVersion}`) {
-            this.serverless.cli.log(`Package version mismatch: NPM: ${javascriptPackageVersion}, Stack: ${haskellPackageVersion[0]}. Versions must be in sync to work correctly.`);
+        if (haskellPackageVersion != javascriptPackageVersion) {
+            this.serverless.cli.log(`Package version mismatch: NPM: ${javascriptPackageVersion}, Stack: ${haskellPackageVersion}. Versions must be in sync to work correctly.`);
             throw new Error("Package version mismatch.");
         }
     }

--- a/serverless-plugin/index.js
+++ b/serverless-plugin/index.js
@@ -159,7 +159,7 @@ class ServerlessPlugin {
                 'field', PACKAGE_NAME, 'version',
                 '--simple-output'
             ]
-        );
+        ).split("\n");
 
         const javascriptPackageVersion = JSON.parse(spawnSync(
             'npm',
@@ -170,8 +170,8 @@ class ServerlessPlugin {
             ]
         ).stdout)['dependencies'][PACKAGE_NAME]['version'];
 
-        if (haskellPackageVersion != javascriptPackageVersion) {
-            this.serverless.cli.log(`Package version mismatch: NPM: ${javascriptPackageVersion}, Stack: ${haskellPackageVersion}. Versions must be in sync to work correctly.`);
+        if (!haskellPackageVersion.includes(javascriptPackageVersion)) {
+            this.serverless.cli.log(`Package version mismatch: NPM: ${javascriptPackageVersion}, Stack: ${haskellPackageVersion.join(", ")}. Versions must be in sync to work correctly.`);
             throw new Error("Package version mismatch.");
         }
     }


### PR DESCRIPTION
As encountered in #58, if serverless-haskell gets pinned via extra-deps in a stack.yaml file, it will result in multiple versions being available. Before the two version lines would get matched against. This splits the version output on newlines, checks if the `javascriptPackageVersion` is in the array, and fails if not, joining back the haskell versions with commas.

This will need to be rebased on top of https://github.com/seek-oss/serverless-haskell/pull/59 though.