### PR TITLE
Handle matching against multiple stack versions, supersedes #60

### DIFF
--- a/serverless-plugin/index.js
+++ b/serverless-plugin/index.js
@@ -154,7 +154,7 @@ class ServerlessPlugin {
         ).split("\n");
         const haskellPackageVersions = stackDependencies.filter(dep => dep.startsWith(`${PACKAGE_NAME} `));
         if (haskellPackageVersions.length === 0) {
-            this.serverless.cli.log(`Could not find ${PACKAGE_NAME} in stack's dependencies. Make sure ${PACKAGE_NAME} is listed as a dependency in your .cabal file, or as an extra-dep in your stack.yaml.`);
+            this.serverless.cli.log(`Could not find ${PACKAGE_NAME} in stack's dependencies. Make sure ${PACKAGE_NAME} you are using LTS 12 (or newer), or add it as an extra-dep in your stack.yaml.`);
             throw new Error("Package not found.");
         }
         const haskellPackageVersion = haskellPackageVersions[0].split(' ')[1];

--- a/serverless-plugin/index.js
+++ b/serverless-plugin/index.js
@@ -154,7 +154,7 @@ class ServerlessPlugin {
         ).split("\n");
         const haskellPackageVersions = stackDependencies.filter(dep => dep.startsWith(`${PACKAGE_NAME} `));
         if (haskellPackageVersions.length === 0) {
-            this.serverless.cli.log(`Could not find ${PACKAGE_NAME} in stack's dependencies.`);
+            this.serverless.cli.log(`Could not find ${PACKAGE_NAME} in stack's dependencies. Make sure ${PACKAGE_NAME} is listed as a dependency in your .cabal file, or as an extra-dep in your stack.yaml.`);
             throw new Error("Package not found.");
         }
         const haskellPackageVersion = haskellPackageVersions[0].split(' ')[1];

--- a/serverless-plugin/index.js
+++ b/serverless-plugin/index.js
@@ -169,7 +169,7 @@ class ServerlessPlugin {
         ).stdout)['dependencies'][PACKAGE_NAME]['version'];
 
         if (haskellPackageVersion != javascriptPackageVersion) {
-            this.serverless.cli.log(`Package version mismatch: NPM: ${javascriptPackageVersion}, Stack: ${haskellPackageVersion}. Versions must be in sync to work correctly. Please install matching versions of NPM and Stack packages.`);
+            this.serverless.cli.log(`Package version mismatch: NPM: ${javascriptPackageVersion}, Stack: ${haskellPackageVersion}. Versions must be in sync to work correctly. Please install matching versions of NPM and Stack packages by either pinning your NPM version to match stack, or adding an extra-dep in your stack.yaml to match the NPM version.`);
             throw new Error("Package version mismatch.");
         }
     }


### PR DESCRIPTION
This supersedes https://github.com/seek-oss/serverless-haskell/pull/60, adding support for multiple installed package versions, and finding the right one, by using `stack ls dependencies` instead of `ghc-pkg`.

The check now happens before `stack build`, because we know it immediately, instead of after it has been built, like with `ghc-pkg`.

Note: Sorry for the multiple PRs, but it was way easier (for me) than rebasing on the different branch :)