### PR TITLE
only build functions with haskell runtime

### DIFF
--- a/serverless-plugin/index.js
+++ b/serverless-plugin/index.js
@@ -257,6 +257,9 @@ class ServerlessPlugin {
 
         this.deployedFunctions().forEach(funcName => {
             const func = service.getFunction(funcName);
+            if (func.runtime !== "haskell") {
+                return;
+            }
             const handlerPattern = /(.*\/)?([^\./]*)\.(.*)/;
             const matches = handlerPattern.exec(func.handler);
 


### PR DESCRIPTION
Addressing #65.

> This is a good suggestion. I suppose the plugin can only build the Haskell function if it has runtime: haskell (and replace the runtime with the actual one later).

I think this addresses your first idea, but I'm not sure what you mean by "replace the runtime with the actual one later". Do you mean that the function's runtime field should be replaced with the project's? E.g., from "haskell" to "nodejs8.10".