### PR TITLE
Use "runtime" option to distinguish Haskell functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Deploying Haskell code onto [AWS Lambda] using [Serverless].
 
   provider:
     name: aws
-    runtime: nodejs8.10
+    runtime: haskell
 
   functions:
     myfunc:

--- a/example-project/serverless.yml
+++ b/example-project/serverless.yml
@@ -2,7 +2,7 @@ service: serverless-haskell-example
 
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: haskell
   region: ap-southeast-2
 
 functions:

--- a/example-project/serverless.yml
+++ b/example-project/serverless.yml
@@ -17,9 +17,3 @@ functions:
 
 plugins:
   - serverless-haskell
-
-custom:
-  haskell:
-    # Always recommended to set this to avoid incompatibility issues with
-    # dependent system libraries.
-    docker: true

--- a/integration-test/expected/local_output_js.txt
+++ b/integration-test/expected/local_output_js.txt
@@ -1,0 +1,3 @@
+{
+    "result": "Hello from JavaScript"
+}

--- a/integration-test/expected/output_js.json
+++ b/integration-test/expected/output_js.json
@@ -1,0 +1,3 @@
+{
+    "result": "Hello from JavaScript"
+}

--- a/integration-test/run.sh
+++ b/integration-test/run.sh
@@ -95,6 +95,12 @@ sls invoke local --function main --data '[4, 5, 6]' | \
 
 diff $EXPECTED/local_output.txt local_output.txt && echo "Expected local result verified."
 
+# Test local invocation of a JavaScript function
+sls invoke local --function jsfunc --data '{}' | \
+    grep -v 'Serverless: ' > local_output_js.txt
+
+diff $EXPECTED/local_output_js.txt local_output_js.txt && echo "Expected local result from JavaScript verified."
+
 # Test serverless-offline
 sls offline start --exec \
     "sh -c 'curl -s http://localhost:3000/hello/integration > offline_output.txt'"
@@ -125,6 +131,11 @@ else
 
     diff $EXPECTED/subdir_output.json subdir_output.json && \
         echo "Expected result verified from subdir function."
+
+    # Run the JavaScript function and verify the results
+    sls invoke --function jsfunc --data '[4, 5, 6]' > output_js.json
+
+    diff $EXPECTED/output_js.json output_js.json && echo "Expected result from JavaScript verified."
 
     # Update a function
     sed 's/33/44/g' Main.hs > Main_modified.hs && mv Main_modified.hs Main.hs

--- a/integration-test/run.sh
+++ b/integration-test/run.sh
@@ -120,7 +120,7 @@ else
 
     # Wait for the logs to be propagated and verify them, ignoring volatile request
     # IDs and extra blank lines
-    sleep 10
+    sleep 20
     sls logs --function main | grep -v RequestId | grep -v '^\W*$' > logs.txt
 
     assert_file_same "sls logs" logs.txt

--- a/integration-test/run.sh
+++ b/integration-test/run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Test packaging a function, deploying it to AWS and running it. With --dry-run,
 # only packaging is tested. With --no-docker, Docker isn't used for packaging.
 
@@ -31,14 +31,13 @@ done
 # Directory of the integration test
 HERE=$(dirname $0)
 
+. $HERE/tests.sh
+
 # Root directory of the repository
 DIST=$(cd $HERE/..; echo $PWD)
 
 # Directory with the test project skeleton
 SKELETON=$(cd $HERE/skeleton; echo $PWD)
-
-# Directory with the expected outputs
-EXPECTED=$(cd $HERE/expected; echo $PWD)
 
 # Stackage resolver series to use
 : "${RESOLVER_SERIES:=lts-12}"
@@ -86,30 +85,30 @@ npm install $DIST/serverless-plugin
 npm install serverless-offline
 
 # Just package the service first
-sls package
-echo "Packaging verified."
+assert_success "sls package" sls package
 
 # Test local invocation
 sls invoke local --function main --data '[4, 5, 6]' | \
     grep -v 'Serverless: ' > local_output.txt
 
-diff $EXPECTED/local_output.txt local_output.txt && echo "Expected local result verified."
+assert_file_same "sls invoke local" local_output.txt
 
 # Test local invocation of a JavaScript function
 sls invoke local --function jsfunc --data '{}' | \
     grep -v 'Serverless: ' > local_output_js.txt
 
-diff $EXPECTED/local_output_js.txt local_output_js.txt && echo "Expected local result from JavaScript verified."
+assert_file_same "sls invoke local (JavaScript)" local_output_js.txt
 
 # Test serverless-offline
 sls offline start --exec \
     "sh -c 'curl -s http://localhost:3000/hello/integration > offline_output.txt'"
-diff $EXPECTED/offline_output.txt offline_output.txt && echo "Expected serverless-offline result verified."
+
+assert_file_same "sls offline" offline_output.txt
 
 if [ "$DRY_RUN" = "true" ]
 then
     # All done (locally)
-    exit 0
+    :
 else
     # Deploy to AWS
     sls deploy
@@ -117,25 +116,24 @@ else
     # Run the function and verify the results
     sls invoke --function main --data '[4, 5, 6]' > output.json
 
-    diff $EXPECTED/output.json output.json && echo "Expected result verified."
+    assert_file_same "sls invoke" output.json
 
     # Wait for the logs to be propagated and verify them, ignoring volatile request
     # IDs and extra blank lines
     sleep 10
     sls logs --function main | grep -v RequestId | grep -v '^\W*$' > logs.txt
 
-    diff $EXPECTED/logs.txt logs.txt && echo "Expected output verified."
+    assert_file_same "sls logs" logs.txt
 
     # Run the function from the subdirectory and verify the result
     sls invoke --function subdir --data '{}' > subdir_output.json
 
-    diff $EXPECTED/subdir_output.json subdir_output.json && \
-        echo "Expected result verified from subdir function."
+    assert_file_same "sls invoke (subdirectory)" subdir_output.json
 
     # Run the JavaScript function and verify the results
     sls invoke --function jsfunc --data '[4, 5, 6]' > output_js.json
 
-    diff $EXPECTED/output_js.json output_js.json && echo "Expected result from JavaScript verified."
+    assert_file_same "sls invoke (JavaScript)" output_js.json
 
     # Update a function
     sed 's/33/44/g' Main.hs > Main_modified.hs && mv Main_modified.hs Main.hs
@@ -144,5 +142,7 @@ else
     # Verify the updated result
     sls invoke --function main --data '[4, 5, 6]' > output_modified.json
 
-    diff $EXPECTED/output_modified.json output_modified.json && echo "Expected updated result verified."
+    assert_file_same "sls invoke (after sls deploy function)" output_modified.json
 fi
+
+end_tests

--- a/integration-test/skeleton/jsfunc/handler.js
+++ b/integration-test/skeleton/jsfunc/handler.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports.main = (event, context, callback) => {
+  callback(null, {
+    result: "Hello from JavaScript"
+  });
+};

--- a/integration-test/skeleton/serverless.yml
+++ b/integration-test/skeleton/serverless.yml
@@ -18,6 +18,10 @@ functions:
   subdir:
     handler: subdir/subtest.main
 
+  jsfunc:
+    runtime: nodejs8.10
+    handler: jsfunc/handler.main
+
 plugins:
 - serverless-haskell
 - serverless-offline

--- a/integration-test/skeleton/serverless.yml
+++ b/integration-test/skeleton/serverless.yml
@@ -2,7 +2,7 @@ service: NAME
 
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: haskell
 
 functions:
   main:

--- a/integration-test/tests.sh
+++ b/integration-test/tests.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Utility functions for tests
+
+# Test running utilities
+TESTS=0
+FAILED=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+# Verify that a command succeeds
+function assert_success() {
+    MESSAGE="$1"
+    shift
+    COMMAND="$@"
+
+    ((++TESTS))
+
+    if $COMMAND
+    then
+        echo -e "${GREEN}$MESSAGE: success${NC}"
+    else
+        echo -e "${RED}${MESSAGE}: fail${NC}"
+        ((++FAILED))
+    fi
+}
+
+# Directory of the integration test
+HERE=$(dirname $0)
+
+# Directory with the expected outputs
+EXPECTED=$(cd $HERE/expected; echo $PWD)
+
+# Test that the file generated is the same as expected
+function assert_file_same() {
+    MESSAGE="$1"
+    shift
+    FILE="$1"
+    shift
+    assert_success "$MESSAGE" diff $EXPECTED/$FILE $FILE
+}
+
+# End testing and indicate the error code
+function end_tests() {
+    if ((FAILED > 0))
+    then
+        echo -e "${RED}Run ${TESTS} tests, ${FAILED} failed.${NC}"
+        exit $FAILED
+    else
+        echo -e "${GREEN}${TESTS} tests passed.${NC}"
+        exit 0
+    fi
+}

--- a/serverless-plugin/index.js
+++ b/serverless-plugin/index.js
@@ -257,6 +257,14 @@ class ServerlessPlugin {
 
         this.deployedFunctions().forEach(funcName => {
             const func = service.getFunction(funcName);
+
+            // Only process Haskell functions
+            const runtime = func.runtime || this.serverless.service.provider.runtime;
+            if (runtime != 'haskell') {
+                return;
+            }
+            service.functions[funcName].runtime = 'nodejs8.10';
+
             const handlerPattern = /(.*\/)?([^\./]*)\.(.*)/;
             const matches = handlerPattern.exec(func.handler);
 

--- a/serverless-plugin/index.js
+++ b/serverless-plugin/index.js
@@ -22,6 +22,12 @@ const IGNORE_LIBRARIES = [
 
 const TEMPLATE = path.resolve(__dirname, 'handler.template.js');
 
+// Runtime handled by this plugin
+const HASKELL_RUNTIME = 'haskell';
+
+// Runtime used by the wrapper
+const BASE_RUNTIME = 'nodejs8.10';
+
 const SERVERLESS_DIRECTORY = '.serverless';
 
 const NO_OUTPUT_CAPTURE = {stdio: ['ignore', process.stdout, process.stderr]};
@@ -259,11 +265,11 @@ class ServerlessPlugin {
             const func = service.getFunction(funcName);
 
             // Only process Haskell functions
-            const runtime = func.runtime || this.serverless.service.provider.runtime;
-            if (runtime != 'haskell') {
+            const runtime = func.runtime || service.provider.runtime;
+            if (runtime != HASKELL_RUNTIME) {
                 return;
             }
-            service.functions[funcName].runtime = 'nodejs8.10';
+            service.functions[funcName].runtime = BASE_RUNTIME;
 
             const handlerPattern = /(.*\/)?([^\./]*)\.(.*)/;
             const matches = handlerPattern.exec(func.handler);
@@ -323,6 +329,11 @@ class ServerlessPlugin {
         });
 
         this.writeHandlers(handlerOptions);
+
+        // Ensure the runtime is set to a sane value for other plugins
+        if (service.provider.runtime == HASKELL_RUNTIME) {
+            service.provider.runtime = BASE_RUNTIME;
+        }
     }
 
     cleanupHandlers(options) {

--- a/src/AWSLambda.hs
+++ b/src/AWSLambda.hs
@@ -24,7 +24,7 @@ package and install the @serverless-haskell@ plugin:
     >
     > provider:
     >   name: aws
-    >   runtime: nodejs8.10
+    >   runtime: haskell
     >
     > functions:
     >   myfunc:


### PR DESCRIPTION
Currently, if the plugin is enabled, all the functions will be built as Haskell, and there is no way to deploy Haskell and other functions together. In vanilla Serverless, it is possible to deploy multiple functions with different runtimes by specifying the `runtime` key in the individual function definitions.

This change makes the plugin use the `runtime` option in the service or individual function definitions to distinguish Haskell functions, and only build with Stack ones where `runtime` is `haskell`.

Before passing control to the main Serverless code, the plugin sets `runtime` to `nodejs8.10` so the functions are deployed properly. Currently the user must set that which is an embarrassing implementation detail.

Fixes #65.

This is a breaking change and will require a version bump.