### PR TITLE
Add authorizer parsing to proxy lambda request context

### DIFF
--- a/src/AWSLambda/Events/APIGateway.hs
+++ b/src/AWSLambda/Events/APIGateway.hs
@@ -96,7 +96,7 @@ $(makeLenses ''RequestIdentity)
 
 data Authorizer = Authorizer
   { _aPrincipalId :: !Text
-  , _aClaims :: !(HashMap Text Text)
+  , _aClaims :: !Object
   , _aContext :: !Object
   } deriving (Eq, Show)
 instance FromJSON Authorizer where

--- a/src/AWSLambda/Events/APIGateway.hs
+++ b/src/AWSLambda/Events/APIGateway.hs
@@ -94,6 +94,19 @@ instance FromJSON RequestIdentity where
       o .:? "user"
 $(makeLenses ''RequestIdentity)
 
+data Authorizer = Authorizer
+  { _aPrincipalId :: !Text
+  , _aClaims :: !(HashMap Text Text)
+  , _aContext :: !Object
+  } deriving (Eq, Show)
+instance FromJSON Authorizer where
+  parseJSON = withObject "Authorizer" $ \o ->
+    Authorizer
+      <$> o .: "principalId"
+      <*> o .:? "claims" .!= mempty
+      <*> (pure $ HashMap.delete "principalId" $ HashMap.delete "claims" o)
+$(makeLenses ''Authorizer)
+
 data ProxyRequestContext = ProxyRequestContext
   { _prcPath         :: !(Maybe Text)
   , _prcAccountId    :: !Text
@@ -105,6 +118,7 @@ data ProxyRequestContext = ProxyRequestContext
   , _prcHttpMethod   :: !Text
   , _prcApiId        :: !Text
   , _prcProtocol     :: !Text
+  , _prcAuthorizer   :: !Authorizer
   } deriving (Eq, Show)
 $(deriveFromJSON (aesonDrop 4 camelCase) ''ProxyRequestContext)
 $(makeLenses ''ProxyRequestContext)

--- a/test/AWSLambda/Events/APIGatewaySpec.hs
+++ b/test/AWSLambda/Events/APIGatewaySpec.hs
@@ -72,7 +72,15 @@ sampleGetRequestJSON = [r|
     },
     "resourcePath": "/{proxy+}",
     "httpMethod": "GET",
-    "apiId": "wt6mne2s9k"
+    "apiId": "wt6mne2s9k",
+    "authorizer": {
+      "principalId": "test-principalId",
+      "claims": {
+        "email": "test@example.com",
+        "email_verified": true
+      },
+      "custom_context": 10
+    }
   },
   "resource": "/{proxy+}",
   "httpMethod": "GET",
@@ -143,6 +151,13 @@ sampleGetRequest =
     , _prcHttpMethod = "GET"
     , _prcApiId = "wt6mne2s9k"
     , _prcProtocol = "HTTP/1.1"
+    , _prcAuthorizer =
+      Authorizer
+      { _aPrincipalId = "test-principalId"
+      , _aClaims = HashMap.fromList [("email", toJSON ("test@example.com" :: Text)), ("email_verified", toJSON True)]
+      , _aContext = HashMap.fromList [("custom_context", toJSON (10 :: Int))]
+      }
+      
     }
   , _agprqBody = Nothing
   }


### PR DESCRIPTION
This allows access to the authorizer propery on the api gateway lambda request context.  The authorizier propery is used during cognito user pools where authorizer.claims contains the claims from the token.  The authorizer is also used with lambda authorizers where the return value from the lambda authorizer claims is put directly on the authorizer property.

Documentation is here: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html