### PR TITLE
Remove workaround for Stack <1.9 trying to sign package

### DIFF
--- a/travis/deploy
+++ b/travis/deploy
@@ -22,9 +22,7 @@ end
 hackage_uploaded = system('stack', 'upload', '.', '--no-signature')
 if not hackage_uploaded
   print "Failed to upload to Hackage.\n"
-  # FIXME: Stack still tries to sign the package and fails
-  # https://github.com/commercialhaskell/stack/issues/3739
-  # exit(1)
+  exit(1)
 end
 
 # Release to NPM


### PR DESCRIPTION
The fix for https://github.com/commercialhaskell/stack/issues/3739 was finally released in 1.9.1, workaround no longer needed.