### PR TITLE
API Gateway: authorizer in the request context is not always present

### DIFF
--- a/src/AWSLambda/Events/APIGateway.hs
+++ b/src/AWSLambda/Events/APIGateway.hs
@@ -95,14 +95,14 @@ instance FromJSON RequestIdentity where
 $(makeLenses ''RequestIdentity)
 
 data Authorizer = Authorizer
-  { _aPrincipalId :: !Text
+  { _aPrincipalId :: !(Maybe Text)
   , _aClaims :: !Object
   , _aContext :: !Object
   } deriving (Eq, Show)
 instance FromJSON Authorizer where
   parseJSON = withObject "Authorizer" $ \o ->
     Authorizer
-      <$> o .: "principalId"
+      <$> o .:? "principalId"
       <*> o .:? "claims" .!= mempty
       <*> (pure $ HashMap.delete "principalId" $ HashMap.delete "claims" o)
 $(makeLenses ''Authorizer)
@@ -118,7 +118,7 @@ data ProxyRequestContext = ProxyRequestContext
   , _prcHttpMethod   :: !Text
   , _prcApiId        :: !Text
   , _prcProtocol     :: !Text
-  , _prcAuthorizer   :: !Authorizer
+  , _prcAuthorizer   :: !(Maybe Authorizer)
   } deriving (Eq, Show)
 $(deriveFromJSON (aesonDrop 4 camelCase) ''ProxyRequestContext)
 $(makeLenses ''ProxyRequestContext)

--- a/test/AWSLambda/Events/APIGatewaySpec.hs
+++ b/test/AWSLambda/Events/APIGatewaySpec.hs
@@ -152,8 +152,8 @@ sampleGetRequest =
     , _prcApiId = "wt6mne2s9k"
     , _prcProtocol = "HTTP/1.1"
     , _prcAuthorizer =
-      Authorizer
-      { _aPrincipalId = "test-principalId"
+      Just Authorizer
+      { _aPrincipalId = Just "test-principalId"
       , _aClaims = HashMap.fromList [("email", toJSON ("test@example.com" :: Text)), ("email_verified", toJSON True)]
       , _aContext = HashMap.fromList [("custom_context", toJSON (10 :: Int))]
       }


### PR DESCRIPTION
With more testing against lambda and api gateway authorizers, it is weird because sometimes for routes with no auth, api gateway doesn't send the authorizer field at all in the request context but sometimes it sends an empty object with no claims.  I couldn't figure out when an empty object is sent and when the field is just missing.

In any case, the fix is to just make the authorizer field optional in the request context.  Just in case I also made the prinicpalId field optional so the parsing doesn't fail if it is missing.