### PR TITLE
Fix regressions in 0.8.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .stack-work
 *.cabal
 /example-project/package-lock.json
+/integration-test/run

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,13 @@ For the changes in v0.6.x, see this file on the corresponding branch.
 
 ## Unreleased changes
 
+* Change the communication method between the JavaScript wrapper and the Haskell
+  process to TCP. This fixes errors like "Resource vanished: broken pipe" when
+  running the Haskell executable standalone.
+* Do not crash when `ldd` is not found when locally invoking a function on macOS.
+* Fix error message about no Haskell functions being found when invoking a
+  function locally.
+
 ## 0.8.3
 
 * It is now an error if the plugin is enabled but there are no functions with

--- a/README.md
+++ b/README.md
@@ -135,7 +135,10 @@ an AWS account. To run manually:
 * To verify just the packaging, without deployment, run
   `./integration-test/run.sh --dry-run`.
 * By default, the integration test is run with LTS 12. To specify a different
-series, use `RESOLVER_SERIES=lts-9`.
+  series, use `RESOLVER_SERIES=lts-9`.
+* To avoid creating a temporary directory for every run, specify
+  `--no-clean-dir`. This can speed up repeated test runs, but does not guarantee
+  the same results as a clean test.
 
 ### Releasing
 

--- a/package.yaml
+++ b/package.yaml
@@ -22,6 +22,8 @@ dependencies:
   - http-types
   - iproute
   - lens
+  - network
+  - network-simple
   - text
   - time
   - unix

--- a/serverless-plugin/.eslintrc
+++ b/serverless-plugin/.eslintrc
@@ -3,7 +3,7 @@
     "node": true
   },
   "parserOptions": {
-    "ecmaVersion": 6,
+    "ecmaVersion": 2017,
     "ecmaFeatures": {
       "impliedStrict": true
     }

--- a/serverless-plugin/handler.template.js
+++ b/serverless-plugin/handler.template.js
@@ -1,55 +1,66 @@
 'use strict';
 
 const { spawn } = require('child_process');
+const net = require('net');
 
 function wrapper(options) {
     const executable = options['executable'];
     const execArguments = options['arguments'];
-    return function (event, context, callback) {
+    return async function (event, context) {
         process.env['PATH'] = process.env['PATH'] + ':' +
             process.env['LAMBDA_TASK_ROOT'];
 
+        // Keep track of the output result
+        let output = '';
+        const server = net.createServer(function(socket) {
+            socket.on('data', chunk => output += chunk);
+        });
+
+        const address = await new Promise(
+            resolve =>
+                server.listen({port: 0, host: "127.0.0.1"}, () => resolve(server.address())));
+        const port = address.port;
+
+        process.env['SERVERLESS_HASKELL_COMMUNICATION_PORT'] = `${port}`;
+
         const main = spawn('./' + executable, execArguments, {
-            stdio: ['pipe', process.stdout, process.stderr, 'pipe'],
+            stdio: ['pipe', process.stdout, process.stderr],
         });
         const stdin = main.stdin;
-        const communication = main.stdio[3];
 
         // Send the event to the process
         stdin.end(JSON.stringify(event) + '\n', 'utf8');
 
-        // Keep track of the process output
-        let output = '';
-        communication.on('data', chunk => output += chunk);
-
         let exited = false;
 
-        main.on('exit', function (code) {
-            if (!exited) {
-                exited = true;
-                if (code == 0) {
-                    try {
-                        const result = JSON.parse(output);
-                        callback(null, result);
-                    } catch (err) {
-                        console.error('child process output bad JSON: ' + output);
-                        callback('child process output bad JSON: ' + output);
+        const result = new Promise((resolve, reject) => {
+
+            main.on('exit', function (code) {
+                if (!exited) {
+                    exited = true;
+                    if (code == 0) {
+                        try {
+                            const result = JSON.parse(output);
+                            resolve(result);
+                        } catch (err) {
+                            reject('child process output bad JSON: ' + output);
+                        }
+                    }
+                    else {
+                        reject('child process exited with code ' + code);
                     }
                 }
-                else {
-                    console.error('child process exited with code ' + code);
-                    callback('child process exited with code ' + code);
+            });
+
+            main.on('error', function (err) {
+                if (!exited) {
+                    exited = true;
+                    reject(err, 'child process exited with error: ' + err);
                 }
-            }
+            });
         });
 
-        main.on('error', function (err) {
-            if (!exited) {
-                exited = true;
-                console.error('error: ' + err);
-                callback(err, 'child process exited with error: ' + err);
-            }
-        });
+        return await result;
     };
 }
 

--- a/serverless-plugin/handler.template.js
+++ b/serverless-plugin/handler.template.js
@@ -33,7 +33,7 @@ function wrapper(options) {
 
         let exited = false;
 
-        const result = new Promise((resolve, reject) => {
+        return await new Promise((resolve, reject) => {
 
             main.on('exit', function (code) {
                 if (!exited) {
@@ -59,8 +59,6 @@ function wrapper(options) {
                 }
             });
         });
-
-        return await result;
     };
 }
 

--- a/serverless-plugin/index.js
+++ b/serverless-plugin/index.js
@@ -291,7 +291,7 @@ class ServerlessPlugin {
             this.assertServerlessPackageVersionsMatch(directory, packageName);
 
             // Ensure the executable is built
-            this.serverless.cli.log("Building handler with Stack...");
+            this.serverless.cli.log(`Building handler ${funcName} with Stack...`);
             const res = this.runStack(
                 directory,
                 ['build', `${packageName}:exe:${executableName}`]

--- a/serverless-plugin/index.js
+++ b/serverless-plugin/index.js
@@ -153,6 +153,10 @@ class ServerlessPlugin {
                 error.result.stdout.includes("not a dynamic executable")) {
                 // Static executables have no dependencies
                 return {};
+            } else if (process.platform == 'darwin' && !this.custom.docker) {
+                // Even if ldd was available on macOS, the dependencies won't
+                // translate
+                return {};
             } else {
                 throw error;
             }

--- a/serverless-plugin/index.js
+++ b/serverless-plugin/index.js
@@ -331,7 +331,7 @@ class ServerlessPlugin {
             }
         });
 
-        if (!haskellFunctionsFound) {
+        if (!this.options.function && !haskellFunctionsFound) {
             throw new Error(
                 `Error: no Haskell functions found. ` +
                 `Use 'runtime: ${HASKELL_RUNTIME}' in global or ` +

--- a/src/AWSLambda/Handler.hs
+++ b/src/AWSLambda/Handler.hs
@@ -101,7 +101,7 @@ withResultChannel act = do
     Just communicationPort -> do
       hSetBuffering stdout LineBuffering
       withSocketsDo $
-        connect "localhost" communicationPort $ \(socket, _) ->
+        connect "127.0.0.1" communicationPort $ \(socket, _) ->
           bracket (socketToHandle socket WriteMode) hClose act
     Nothing -> act stdout
 


### PR DESCRIPTION
* Change the communication method between the JavaScript wrapper and the Haskell
  process to TCP. This fixes errors like "Resource vanished: broken pipe" when
  running the Haskell executable standalone.
* Do not crash when `ldd` is not found when locally invoking a function on macOS.
* Fix error message about no Haskell functions being found when invoking a
  function locally.
