### PR TITLE
Add a stack template file

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,32 @@ Deploying Haskell code onto [AWS Lambda] using [Serverless].
 * [Stack]
 * [NPM]
 * [Docker]
+* [Serverless]
 
 ## Usage
+
+There are two ways to start, either via the stack template, or directly modifying a project. You may want to use the manual approach as the template specifies a specific stack resolver.
+
+### Using the stack template
+
+* Create a [Stack] package for your code:
+
+  ```shell
+  stack new mypackage https://raw.githubusercontent.com/seek-oss/serverless-haskell/v0.8.3/serverless-haskell.hsfiles
+  ```
+  
+* Install the dependencies and build the project:
+ 
+  ```shell
+  cd mypackage
+  npm install
+  stack build
+  sls invoke local -f myfunc
+  ```
+  
+  This should invoke serverless locally and display output once everything has built.
+  
+### Manually
 
 * Create a [Stack] package for your code:
 

--- a/bumpversion
+++ b/bumpversion
@@ -92,6 +92,10 @@ sedi -E '/^## Unreleased changes/{G;a\
 sedi -E 's/(version: +)"'$OLD_VERSION'"/\1"'$NEW_VERSION'"/g' package.yaml
 sedi -E 's/^  "version": "'$OLD_VERSION'"/  "version": "'$NEW_VERSION'"/g' serverless-plugin/package.json
 sedi -E 's/^  "version": "'$OLD_VERSION'"/  "version": "'$NEW_VERSION'"/g' serverless-plugin/package-lock.json
+sedi -E 's/^    "serverless-haskell": "^'$OLD_VERSION'"/    "serverless-haskell": "^'$NEW_VERSION'"/g' serverless-haskell.hsfiles
+sedi -E 's/^- serverless-haskell-'$OLD_VERSION'/- serverless-haskell-'$NEW_VERSION'/g' serverless-haskell.hsfiles
+sedi -E 's/serverless-haskell\/v'$OLD_VERSION'/serverless-haskell\/v'$NEW_VERSION'/g' README.md
+
 
 if [ -z $DRY_RUN ]
 then

--- a/serverless-haskell.hsfiles
+++ b/serverless-haskell.hsfiles
@@ -1,0 +1,238 @@
+{-# START_FILE package.yaml #-}
+name:                {{name}}
+version:             0.1.0.0
+github:              "{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}"
+license:             BSD3
+author:              "{{author-name}}{{^author-name}}Author name here{{/author-name}}"
+maintainer:          "{{author-email}}{{^author-email}}example@example.com{{/author-email}}"
+copyright:           "{{copyright}}{{^copyright}}{{year}}{{^year}}2018{{/year}} {{author-name}}{{^author-name}}Author name here{{/author-name}}{{/copyright}}"
+
+extra-source-files:
+- README.md
+- ChangeLog.md
+
+# Metadata used when publishing your package
+# synopsis:            Short description of your package
+# category:            {{category}}{{^category}}Web{{/category}}
+
+# To avoid duplicated efforts in documentation and dealing with the
+# complications of embedding Haddock markup inside cabal files, it is
+# common to point users to the README.md file.
+description:         Please see the README on GitHub at <https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme>
+
+dependencies:
+- base >= 4.7 && < 5
+- serverless-haskell
+- aeson
+
+library:
+  source-dirs: src
+
+executables:
+  {{name}}-exe:
+    main:                Main.hs
+    source-dirs:         app
+    ghc-options:
+    - -threaded
+    - -rtsopts
+    - -with-rtsopts=-N
+    dependencies:
+    - {{name}}
+
+tests:
+  {{name}}-test:
+    main:                Spec.hs
+    source-dirs:         test
+    ghc-options:
+    - -threaded
+    - -rtsopts
+    - -with-rtsopts=-N
+    dependencies:
+    - {{name}}
+
+{-# START_FILE Setup.hs #-}
+import Distribution.Simple
+main = defaultMain
+
+{-# START_FILE test/Spec.hs #-}
+main :: IO ()
+main = putStrLn "Test suite not yet implemented"
+
+{-# START_FILE src/Lib.hs #-}
+module Lib
+    ( someFunc
+    ) where
+
+someFunc :: IO ()
+someFunc = putStrLn "Serverless is running your lambda function!"
+
+{-# START_FILE app/Main.hs #-}
+module Main where
+
+import Lib
+import qualified Data.Aeson as Aeson
+
+import AWSLambda
+
+main = lambdaMain handler
+
+handler :: Aeson.Value -> IO [Int]
+handler evt = do
+  putStrLn "This should go to logs"
+  someFunc
+  print evt
+  pure [1, 2, 3]
+
+{-# START_FILE README.md #-}
+# {{name}}
+
+{-# START_FILE ChangeLog.md #-}
+# Changelog for {{name}}
+
+## Unreleased changes
+
+{-# START_FILE LICENSE #-}
+Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2018{{/year}}
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of {{author-name}}{{^author-name}}Author name here{{/author-name}} nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+{-# START_FILE .gitignore #-}
+.stack-work/
+node_modules/
+{{name}}.cabal
+*~
+
+{-# START_FILE serverless.yml #-}
+service: myservice
+
+provider:
+  name: aws
+  runtime: haskell
+
+functions:
+  myfunc:
+    handler: {{name}}.{{name}}-exe
+    # Here, mypackage is the Haskell package name and myfunc is the executable
+    # name as defined in the Cabal file. The handler field may be prefixed
+    # with a path of the form `dir1/.../dirn`, relative to `serverless.yml`,
+    # which points to the location where the Haskell package `mypackage` is
+    # defined. This prefix is not needed when the Stack project is defined at
+    # the same level as `serverless.yml`.
+
+plugins:
+  - serverless-haskell
+
+{-# START_FILE package.json #-}
+{
+  "name": "{{name}}",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "serverless": "^1.33.2",
+    "serverless-haskell": "^0.8.3"
+  }
+}
+
+{-# START_FILE stack.yaml #-}
+# This file was automatically generated by 'stack init'
+#
+# Some commonly used options have been documented as comments in this file.
+# For advanced use and comprehensive documentation of the format, please see:
+# https://docs.haskellstack.org/en/stable/yaml_configuration/
+
+# Resolver to choose a 'specific' stackage snapshot or a compiler version.
+# A snapshot resolver dictates the compiler version and the set of packages
+# to be used for project dependencies. For example:
+#
+# resolver: lts-3.5
+# resolver: nightly-2015-09-21
+# resolver: ghc-7.10.2
+# resolver: ghcjs-0.1.0_ghc-7.10.2
+#
+# The location of a snapshot can be provided as a file or url. Stack assumes
+# a snapshot provided as a file might change, whereas a url resource does not.
+#
+# resolver: ./custom-snapshot.yaml
+# resolver: https://example.com/snapshots/2018-01-01.yaml
+resolver: lts-12.19
+
+# User packages to be built.
+# Various formats can be used as shown in the example below.
+#
+# packages:
+# - some-directory
+# - https://example.com/foo/bar/baz-0.0.2.tar.gz
+# - location:
+#    git: https://github.com/commercialhaskell/stack.git
+#    commit: e7b331f14bcffb8367cd58fbfc8b40ec7642100a
+# - location: https://github.com/commercialhaskell/stack/commit/e7b331f14bcffb8367cd58fbfc8b40ec7642100a
+#  subdirs:
+#  - auto-update
+#  - wai
+packages:
+- .
+# Dependency packages to be pulled from upstream that are not in the resolver
+# using the same syntax as the packages field.
+# (e.g., acme-missiles-0.3)
+extra-deps:
+- serverless-haskell-0.8.3
+
+# Override default flag values for local packages and extra-deps
+# flags: {}
+
+# Extra package databases containing global packages
+# extra-package-dbs: []
+
+# Control whether we use the GHC we find on the path
+# system-ghc: true
+#
+# Require a specific version of stack, using version ranges
+# require-stack-version: -any # Default
+# require-stack-version: ">=1.7"
+#
+# Override the architecture used by stack, especially useful on Windows
+# arch: i386
+# arch: x86_64
+#
+# Extra directories used by stack for building
+# extra-include-dirs: [/path/to/dir]
+# extra-lib-dirs: [/path/to/dir]
+#
+# Allow a newer minor version of GHC than the snapshot specifies
+# compiler-check: newer-minor


### PR DESCRIPTION
Apologies for the drive by PR, I'm happy to clean anything up as necessary.

As mentioned in #25, this will create a basic templated project with a version of
`serverless-haskell` pinned at a given version. Templates can come from raw urls, which I'm doing here.

I've updated `bumpversion`, and the `README.md`, I'm not sure if there's anything else I should add to this?

To try it out directly, you can run

```
stack new mypackage https://raw.githubusercontent.com/khanage/serverless-haskell/add-stack-template-file/serverless-haskell.hsfiles
cd mypackage
npm install
stack build
sls invoke local -f myfunc
```