### PR TITLE
Fix the template URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ In either case, you will want to have [Serverless] installed, eg. `npm install -
 * Create a [Stack] package for your code:
 
   ```shell
-  stack new mypackage https://raw.githubusercontent.com/seek-oss/serverless-haskell/v0.8.4/serverless-haskell.hsfiles
+  stack new mypackage https://raw.githubusercontent.com/seek-oss/serverless-haskell/master/serverless-haskell.hsfiles
   ```
 
 * Update the resolver in the `stack.yaml` file. This is hardcoded as the resolver number is not known at template interpolation time. You should pick either the latest resolver, or one you have used before and have thus prebuilt many of the core packages for.

--- a/bumpversion
+++ b/bumpversion
@@ -94,7 +94,6 @@ sedi -E 's/^  "version": "'$OLD_VERSION'"/  "version": "'$NEW_VERSION'"/g' serve
 sedi -E 's/^  "version": "'$OLD_VERSION'"/  "version": "'$NEW_VERSION'"/g' serverless-plugin/package-lock.json
 sedi -E 's/^    "serverless-haskell": "^'$OLD_VERSION'"/    "serverless-haskell": "^'$NEW_VERSION'"/g' serverless-haskell.hsfiles
 sedi -E 's/^- serverless-haskell-'$OLD_VERSION'/- serverless-haskell-'$NEW_VERSION'/g' serverless-haskell.hsfiles
-sedi -E 's/serverless-haskell\/v'$OLD_VERSION'/serverless-haskell\/v'$NEW_VERSION'/g' README.md
 
 
 if [ -z $DRY_RUN ]


### PR DESCRIPTION
The template URL was pointing to an old tag and just didn't work. I've changed it to look at master for now. The other option is bumping the version of the package, but doing that seems unnecessary as I can't think of a great reason to prefer a particular version in the README