### PR TITLE
Fix expanding variables in custom section

### DIFF
--- a/integration-test/run.sh
+++ b/integration-test/run.sh
@@ -89,7 +89,7 @@ fi
 cd $DIR
 
 # Copy the test files over, replacing the values
-SED="sed s!NAME!$NAME!g;s!DIST!$DIST!g;s!RESOLVER!$RESOLVER!g;s!DOCKER!$DOCKER!g;s!EXTRA_DEPS!$EXTRA_DEPS!g"
+SED="sed s!NAME!$NAME!g;s!DIST!$DIST!g;s!RESOLVER!$RESOLVER!g;s!DOCKER_DEFAULT!$DOCKER!g;s!EXTRA_DEPS!$EXTRA_DEPS!g"
 for FILE in $(find $SKELETON -type f | grep -v /\\. | sed "s!$SKELETON/!!")
 do
     mkdir -p $(dirname $FILE)
@@ -105,6 +105,11 @@ npm install serverless-offline
 
 # Just package the service first
 assert_success "sls package" sls package
+
+# Test packaging without Docker
+FORCE_DOCKER=false sls package > no_docker_sls_package.txt
+assert_success "custom variable disables Docker" \
+                grep -q "Serverless: Warning: not using Docker to build" no_docker_sls_package.txt
 
 # Test local invocation
 sls invoke local --function main --data '[4, 5, 6]' | \

--- a/integration-test/skeleton/serverless.yml
+++ b/integration-test/skeleton/serverless.yml
@@ -33,4 +33,9 @@ custom:
       - one
       - two
       - --three
-    docker: DOCKER
+    # environment variables appear as strings. Index that string into a
+    # dictionary with actual boolean values to get the boolean back
+    docker: ${self:custom.boolean.${env:FORCE_DOCKER, "DOCKER_DEFAULT"}}
+  boolean:
+    true: true
+    false: false

--- a/integration-test/tests.sh
+++ b/integration-test/tests.sh
@@ -10,14 +10,13 @@ GREEN='\033[0;32m'
 NC='\033[0m'
 
 # Verify that a command succeeds
-function assert_success() {
+assert_success() {
     MESSAGE="$1"
     shift
-    COMMAND="$@"
 
     ((++TESTS))
 
-    if $COMMAND
+    if "$@"
     then
         echo -e "${GREEN}$MESSAGE: success${NC}"
     else
@@ -33,7 +32,7 @@ HERE=$(dirname $0)
 EXPECTED=$(cd $HERE/expected; echo $PWD)
 
 # Test that the file generated is the same as expected
-function assert_file_same() {
+assert_file_same() {
     MESSAGE="$1"
     shift
     FILE="$1"
@@ -42,7 +41,7 @@ function assert_file_same() {
 }
 
 # End testing and indicate the error code
-function end_tests() {
+end_tests() {
     if ((FAILED > 0))
     then
         echo -e "${RED}Run ${TESTS} tests, ${FAILED} failed.${NC}"


### PR DESCRIPTION
Serverless [supports variables](https://serverless.com/framework/docs/providers/aws/guide/variables/) in the configuration file.

However, they are not expanded in the plugin _constructor_ yet (https://forum.serverless.com/t/serverless-plugin-resolving-variable-references/2233/2), so specifying `docker: false` via a _variable_ does not turn off Docker.

This PR fixes the expanding by only checking the value of `docker` _after_ the constructor.

See `fix-variables-test` for a failing test.