### PR TITLE
Allow more time for caching on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ cache:
   - $HOME/.ghc
   - $HOME/.cabal
   - $HOME/.stack
+  timeout: 600
 
 matrix:
   include:


### PR DESCRIPTION
Builds for LTS 13 failed to upload the cache previously, leading to each commit taking upwards of 30 minutes to build there. Allow more time for caching so that future builds are fast.