### PR TITLE
Move sls package test out of dry run section

### DIFF
--- a/example-project/package.json
+++ b/example-project/package.json
@@ -6,7 +6,7 @@
     "test": "test"
   },
   "dependencies": {
-    "serverless": "^1.27.3",
+    "serverless": "^1.41.0",
     "serverless-haskell": "file:../serverless-plugin"
   },
   "devDependencies": {},

--- a/integration-test/run.sh
+++ b/integration-test/run.sh
@@ -20,6 +20,10 @@ do
             REUSE_DIR=true
             shift
             ;;
+        --failfast)
+            FAILFAST=true
+            shift
+            ;;
         *)
             shift
             ;;

--- a/integration-test/run.sh
+++ b/integration-test/run.sh
@@ -107,14 +107,6 @@ npm install serverless
 npm install $DIST/serverless-plugin
 npm install serverless-offline
 
-# Just package the service first
-assert_success "sls package" sls package
-
-# Test packaging without Docker
-FORCE_DOCKER=false sls package > no_docker_sls_package.txt
-assert_success "custom variable disables Docker" \
-                grep -q "Serverless: Warning: not using Docker to build" no_docker_sls_package.txt
-
 # Test local invocation
 sls invoke local --function main --data '[4, 5, 6]' | \
     grep -v 'Serverless: ' > local_output.txt
@@ -138,6 +130,14 @@ then
     # All done (locally)
     :
 else
+    # Just package the service first
+    assert_success "sls package" sls package
+
+    # Test packaging without Docker
+    FORCE_DOCKER=false sls package > no_docker_sls_package.txt
+    assert_success "custom variable disables Docker" \
+        grep -q "Serverless: Warning: not using Docker to build" no_docker_sls_package.txt
+
     # Deploy to AWS
     sls deploy
 

--- a/integration-test/tests.sh
+++ b/integration-test/tests.sh
@@ -22,6 +22,11 @@ assert_success() {
     else
         echo -e "${RED}${MESSAGE}: fail${NC}"
         ((++FAILED))
+        if [ "$FAILFAST" = "true" ]
+        then
+            echo -e "${RED}Aborting further tests.${NC}"
+            exit $FAILED
+        fi
     fi
 }
 


### PR DESCRIPTION
Due to https://github.com/serverless/serverless/issues/6034, `sls package` cannot be run without AWS credentials.