### PR TITLE
Build the whole project with Stack by default

### DIFF
--- a/serverless-plugin/index.js
+++ b/serverless-plugin/index.js
@@ -77,6 +77,7 @@ class ServerlessPlugin {
                 stackBuildArgs: [],
                 arguments: {},
                 docker: true,
+                buildAll: true,
             },
             this.serverless.service.custom &&
                 this.serverless.service.custom.haskell ||
@@ -292,10 +293,11 @@ class ServerlessPlugin {
 
             // Ensure the executable is built
             this.serverless.cli.log(`Building handler ${funcName} with Stack...`);
-            const res = this.runStack(
-                directory,
-                ['build', `${packageName}:exe:${executableName}`]
-            );
+            const buildCommand = this.custom().buildAll ?
+                ['build'] :
+                ['build', `${packageName}:exe:${executableName}`];
+
+            const res = this.runStack(directory, buildCommand);
 
             // Copy the executable to the destination directory
             const stackInstallRoot = this.runStackOutput(

--- a/src/AWSLambda.hs
+++ b/src/AWSLambda.hs
@@ -94,6 +94,17 @@ binary might not have the required libraries to run on Lambda.
     > custom:
     >   haskell:
     >     docker: false
+
+* By default, @stack build@ command is invoked to build all the project's
+executables. To only build the ones used in the handlers, set @buildAll@ key to
+@false@. Note that at least Stack 1.9.3 has better caching behavior when 
+building the whole project, as it doesn't need to reconfigure the build for the
+individual ones every time.
+
+    > custom:
+    >   haskell:
+    >     buildAll: false
+
 -}
 module AWSLambda
   ( Handler.lambdaMain


### PR DESCRIPTION
`stack build <component>` has to reconfigure _something_ (Cabal?) each time, which makes for slower rebuilds. Make `stack build` the default, with an option to revert to building individual executables instead.