### PR TITLE
Stack 2 compatibility

### DIFF
--- a/integration-test/run.sh
+++ b/integration-test/run.sh
@@ -55,15 +55,6 @@ RESOLVER=$(curl -s https://www.stackage.org/download/snapshots.json | \
                jq -r '."'$RESOLVER_SERIES'"')
 echo "Using resolver: $RESOLVER"
 
-# Extra dependencies to use for the resolver
-EXTRA_DEPS_YAML=$HERE/extra-deps.$RESOLVER_SERIES
-if [ -f $EXTRA_DEPS_YAML ]
-then
-    EXTRA_DEPS=$(cat $EXTRA_DEPS_YAML)
-else
-    EXTRA_DEPS=''
-fi
-
 if [ -n "$REUSE_DIR" ]
 then
     DIR=$HERE/run
@@ -93,7 +84,7 @@ fi
 cd $DIR
 
 # Copy the test files over, replacing the values
-SED="sed s!NAME!$NAME!g;s!DIST!$DIST!g;s!RESOLVER!$RESOLVER!g;s!DOCKER_DEFAULT!$DOCKER!g;s!EXTRA_DEPS!$EXTRA_DEPS!g"
+SED="sed s!NAME!$NAME!g;s!DIST!$DIST!g;s!RESOLVER!$RESOLVER!g;s!DOCKER_DEFAULT!$DOCKER!g"
 for FILE in $(find $SKELETON -type f | grep -v /\\. | sed "s!$SKELETON/!!")
 do
     mkdir -p $(dirname $FILE)

--- a/integration-test/skeleton/stack.yaml
+++ b/integration-test/skeleton/stack.yaml
@@ -1,6 +1,4 @@
 resolver: RESOLVER
 
-packages:
-- .
-- location: DIST
-  extra-dep: true
+extra-deps:
+- DIST

--- a/integration-test/skeleton/stack.yaml
+++ b/integration-test/skeleton/stack.yaml
@@ -4,5 +4,3 @@ packages:
 - .
 - location: DIST
   extra-dep: true
-
-extra-deps: [EXTRA_DEPS]

--- a/integration-test/skeleton/subdir/stack.yaml
+++ b/integration-test/skeleton/subdir/stack.yaml
@@ -1,6 +1,4 @@
 resolver: RESOLVER
 
-packages:
-- .
-- location: DIST
-  extra-dep: true
+extra-deps:
+- DIST

--- a/integration-test/skeleton/subdir/stack.yaml
+++ b/integration-test/skeleton/subdir/stack.yaml
@@ -4,5 +4,3 @@ packages:
 - .
 - location: DIST
   extra-dep: true
-
-extra-deps: [EXTRA_DEPS]


### PR DESCRIPTION
In Stack 2, this syntax is no longer valid:

```
packages:
- .
- location: somewhere
  extra-dep: true
```