### PR TITLE
Use ObjectVersionId newtype

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,8 @@ For the changes in v0.6.x, see this file on the corresponding branch.
 
 ## Unreleased changes
 
+## 0.9.0
+
 * Use `ObjectVersionId` from `amazonka-s3` in S3 events.
 
 ## 0.8.11

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,8 @@ For the changes in v0.6.x, see this file on the corresponding branch.
 
 ## Unreleased changes
 
+* Use `ObjectVersionId` from `amazonka-s3` in S3 events.
+
 ## 0.8.11
 
 * Update the list of system libraries available on AWS Lambda (#108).

--- a/package.yaml
+++ b/package.yaml
@@ -1,7 +1,7 @@
 name:                serverless-haskell
 category:            AWS, Cloud, Network
 maintainer:          akotlyarov@seek.com.au
-version:             "0.8.11"
+version:             "0.9.0"
 github:              seek-oss/serverless-haskell
 license:             MIT
 synopsis:            Deploying Haskell code onto AWS Lambda using Serverless

--- a/serverless-haskell.hsfiles
+++ b/serverless-haskell.hsfiles
@@ -211,7 +211,7 @@ packages:
 # using the same syntax as the packages field.
 # (e.g., acme-missiles-0.3)
 extra-deps:
-- serverless-haskell-0.8.11
+- serverless-haskell-0.9.0
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/serverless-plugin/package-lock.json
+++ b/serverless-plugin/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-haskell",
-  "version": "0.8.11",
+  "version": "0.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/serverless-plugin/package.json
+++ b/serverless-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-haskell",
-  "version": "0.8.11",
+  "version": "0.9.0",
   "description": "Deploy Haskell binaries onto AWS Lambda",
   "main": "index.js",
   "scripts": {

--- a/src/AWSLambda/Events/S3Event.hs
+++ b/src/AWSLambda/Events/S3Event.hs
@@ -44,7 +44,7 @@ data S3ObjectEntity = S3ObjectEntity
   , _soeKey       :: !S3.ObjectKey
   , _soeSize      :: !(Maybe Integer)
   , _soeSequencer :: !Text
-  , _soeVersionId :: !(Maybe Text)
+  , _soeVersionId :: !(Maybe S3.ObjectVersionId)
   } deriving (Eq, Show)
 
 $(deriveFromJSON (aesonDrop 4 camelCase) ''S3ObjectEntity)

--- a/src/AWSLambda/Orphans.hs
+++ b/src/AWSLambda/Orphans.hs
@@ -17,6 +17,8 @@ deriving instance FromJSON S3.BucketName
 
 deriving instance FromJSON S3.ObjectKey
 
+deriving instance FromJSON S3.ObjectVersionId
+
 instance FromJSON S3.ETag where
   parseJSON = withText "ETag" $ either fail return . fromText
 


### PR DESCRIPTION
Small PR. It's a breaking change but not one that should be hard to fix. `ObjectVersionId` is a newtype that is used in `amazonka-s3` for referring to S3 object versions. We already use `BucketName` and `ObjectKey` from `amazonka-s3` so it makes sense to use `ObjectVersionId` too for consistency.