### PR TITLE
Separate deployment stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,16 +40,9 @@ matrix:
     name: "npm"
 
   - stage: deploy
-    script: skip
-    deploy:
-      provider: script
-      script: ./travis/deploy
-      skip_cleanup: true
-      on:
-        tags: true
-        all_branches: true
-        condition:
-          - '$TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$'
+    script: ./travis/deploy
+    if:
+      - tag =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/
 
 before_install: source ./travis/before_install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,11 +48,8 @@ matrix:
       on:
         tags: true
         all_branches: true
-        # condition:
-        #   - '$BUILD = stack'
-        #   - '$ARGS = ""'
-        #   - '$(uname) = Linux'
-        #   - '$TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$'
+        condition:
+          - '$TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$'
 
 before_install: source ./travis/before_install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ cache:
   - $HOME/.stack
   timeout: 600
 
-matrix:
+jobs:
   include:
   - env: BUILD=integration ARGS=""
     name: "Default"
@@ -41,8 +41,7 @@ matrix:
 
   - stage: deploy
     script: ./travis/deploy
-    if:
-      - tag =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/
+    if: tag =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/
 
 before_install: source ./travis/before_install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,44 +16,46 @@ cache:
 matrix:
   include:
   - env: BUILD=integration ARGS=""
-    compiler: ": #integration default"
+    name: "Default"
 
   - env: BUILD=integration RESOLVER_SERIES=lts-14 ARGS="--resolver lts-14"
-    compiler: ": #integration LTS 14"
+    name: "LTS 14"
 
   - env: BUILD=integration RESOLVER_SERIES=lts-13 ARGS="--resolver lts-13"
-    compiler: ": #integration LTS 13"
+    name: "LTS 13"
 
   - env: BUILD=integration RESOLVER_SERIES=lts-12 ARGS="--resolver lts-12"
-    compiler: ": #integration LTS 12"
+    name: "LTS 12"
 
   - env: BUILD=integration RESOLVER_SERIES=lts-11 ARGS="--resolver lts-11"
-    compiler: ": #integration LTS 11"
+    name: "LTS 11"
 
   - env: BUILD=integration RESOLVER_SERIES=lts-10 ARGS="--resolver lts-10 --stack-yaml stack-travis.yaml"
-    compiler: ": #integration LTS 10"
+    name: "LTS 10"
 
   - env: BUILD=integration RESOLVER_SERIES=lts-9 ARGS="--resolver lts-9 --stack-yaml stack-travis.yaml"
-    compiler: ": #integration LTS 9"
+    name: "LTS 9"
 
   - env: BUILD=npm
-    compiler: ": #npm"
+    name: "npm"
+
+  - stage: deploy
+    script: skip
+    deploy:
+      provider: script
+      script: ./travis/deploy
+      skip_cleanup: true
+      on:
+        tags: true
+        all_branches: true
+        # condition:
+        #   - '$BUILD = stack'
+        #   - '$ARGS = ""'
+        #   - '$(uname) = Linux'
+        #   - '$TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$'
 
 before_install: source ./travis/before_install
 
 install: source ./travis/install
 
 script: source ./travis/build
-
-deploy:
-  provider: script
-  script: ./travis/deploy
-  skip_cleanup: true
-  on:
-    tags: true
-    all_branches: true
-    condition:
-      - '$BUILD = stack'
-      - '$ARGS = ""'
-      - '$(uname) = Linux'
-      - '$TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$'

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,8 @@ For the changes in v0.6.x, see this file on the corresponding branch.
 
 ## Unreleased changes
 
+* More robust deployment process.
+
 ## 0.9.2
 
 * Support LTS 14.

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,10 +3,31 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    hackage: amazonka-core-1.6.1@sha256:9bc59ce403c6eeba3b3eaf3f10e5f0b6a33b6edbbf8f6de0dd6f4c67b86fa698,5135
+    pantry-tree:
+      size: 3438
+      sha256: c13e643176308771491ec0e06390e269047bb1b28be4535992842f7426a95eb4
+  original:
+    hackage: amazonka-core-1.6.1@sha256:9bc59ce403c6eeba3b3eaf3f10e5f0b6a33b6edbbf8f6de0dd6f4c67b86fa698,5135
+- completed:
+    hackage: amazonka-kinesis-1.6.1@sha256:439479d6d7f4a731a2f1feeb3a4c653d266c11d655cd4085608e157eb524c51b,3998
+    pantry-tree:
+      size: 6151
+      sha256: 093cc250ae84c361bbeb2c3b8974f811f5110b638f89b65c9d51a940e2363331
+  original:
+    hackage: amazonka-kinesis-1.6.1@sha256:439479d6d7f4a731a2f1feeb3a4c653d266c11d655cd4085608e157eb524c51b,3998
+- completed:
+    hackage: amazonka-s3-1.6.1@sha256:9d07240fca59ad5197fb614ce3051e701e4951e6d4625a2dab4a9c17a1900194,6317
+    pantry-tree:
+      size: 18385
+      sha256: 5cab233d241615764d9fd6927bc397f02887154450a9932c38c2e17ea86d79bc
+  original:
+    hackage: amazonka-s3-1.6.1@sha256:9d07240fca59ad5197fb614ce3051e701e4951e6d4625a2dab4a9c17a1900194,6317
 snapshots:
 - completed:
-    size: 545658
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/12.yaml
-    sha256: 26b807457213126d26b595439d705dc824dbb7618b0de6b900adc2bf6a059406
-  original: lts-14.12
+    size: 525876
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/13.yaml
+    sha256: 4a0e79eb194c937cc2a1852ff84d983c63ac348dc6bad5f38d20cab697036eef
+  original: lts-14.13

--- a/travis/before_install
+++ b/travis/before_install
@@ -2,9 +2,6 @@
 
 set -ex
 
-# Using compiler above sets CC to an invalid value, so unset it
-unset CC
-
 # We want to always allow newer versions of packages when building on GHC HEAD
 CABALARGS=""
 


### PR DESCRIPTION
0.9.2 wasn't released because the changes to `.travis.yml` meant the deployment stage was never run (it relied on a specific build job which was merged into another).

This PR separates [build and deployment stages in CI](https://docs.travis-ci.com/user/build-stages/) and ensures the deployment stage is run after _all_ build jobs are successful.

Because the deployment stage is no longer attached to any single build job, further changes to the build jobs (e.g. adding or removing LTS) will not affect the deployment process.