### PR TITLE
Update Node runtime to 12.x

### DIFF
--- a/serverless-plugin/config.js
+++ b/serverless-plugin/config.js
@@ -6,7 +6,7 @@
 const HASKELL_RUNTIME = 'haskell';
 
 // Runtime used by the wrapper
-const BASE_RUNTIME = 'nodejs10.x';
+const BASE_RUNTIME = 'nodejs12.x';
 
 // Docker image used as reference
 const DOCKER_IMAGE = 'lambci/lambda:' + BASE_RUNTIME;


### PR DESCRIPTION
AWS Lambda supports Node 12 now.