### PR TITLE
Don't parse all objdump output when checking glibc version

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,9 @@ For the changes in v0.6.x, see this file on the corresponding branch.
 
 ## Unreleased changes
 
+* Speed up checking required glibc version, avoiding potentially very long
+  deployment times (#124).
+
 ## 0.10.1
 
 * Support LTS 15.

--- a/serverless-plugin/ld.js
+++ b/serverless-plugin/ld.js
@@ -17,16 +17,11 @@ function parseLdOutput(output) {
     return result;
 }
 
-function flatten(arr) {
-    return arr.reduce((x, y) => x.concat(y), []);
-}
+const glibcPattern = /\bGLIBC_([0-9.]+)\b/gm;
 
 // Parse output of objdump -T and return minimum glibc version required
 function parseObjdumpOutput(output) {
-    const glibcPrefix = 'GLIBC_';
-    const glibcReferences = flatten(output.split('\n').map(
-        ln => ln.split(/\s+/))).filter(p => p.indexOf(glibcPrefix) === 0);
-    const versions = glibcReferences.map(s => version.parse(s.substring(glibcPrefix.length)));
+    const versions = output.matchAll(glibcPattern).map(match => version.parse(match[1]));
     if (versions.length > 0) {
         return versions.reduce(version.max);
     } else {

--- a/serverless-plugin/ld.js
+++ b/serverless-plugin/ld.js
@@ -17,16 +17,19 @@ function parseLdOutput(output) {
     return result;
 }
 
-const glibcPattern = /\bGLIBC_([0-9.]+)\b/gm;
-
 // Parse output of objdump -T and return minimum glibc version required
 function parseObjdumpOutput(output) {
-    const versions = output.matchAll(glibcPattern).map(match => version.parse(match[1]));
-    if (versions.length > 0) {
-        return versions.reduce(version.max);
-    } else {
-        return null;
+    const glibcPattern = /\bGLIBC_([0-9.]+)\b/g;
+
+    let maxVersion = null;
+    let match;
+    while (match = glibcPattern.exec(output)) {
+        const thisVersion = version.parse(match[1]);
+        if (!maxVersion || version.greater(thisVersion, maxVersion)) {
+            maxVersion = thisVersion;
+        }
     }
+    return maxVersion;
 }
 
 module.exports.parseLdOutput = parseLdOutput;

--- a/travis/before_install
+++ b/travis/before_install
@@ -9,7 +9,7 @@ mkdir -p ~/.local/bin
 curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
 
 sudo apt-get update
-curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
+curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
 sudo apt-get install -y nodejs
 
 set +ex


### PR DESCRIPTION
I've updated NodeJS on Travis to 12, but it should still work on 10 too.