### PR TITLE
Fix deployment

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -24,7 +24,7 @@ jobs:
         with:
           key: deploy
           path: ~/.npm
-      - name: Deploy (dry run)
+      - name: Deploy
         run: ./deploy
         env:
           HACKAGE_USERNAME: ${{ secrets.HACKAGE_USERNAME }}

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,8 @@ For the changes in v0.6.x, see this file on the corresponding branch.
 
 ## Unreleased changes
 
+* Fix deployment (#137).
+
 ## 0.11.1
 
 * Fix deployment (#136).

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,3 +6,5 @@ nix:
   packages:
     - zlib.dev
     - zlib.out
+# Work around https://github.com/commercialhaskell/stack/issues/5290
+save-hackage-creds: false


### PR DESCRIPTION
We've used a new feature of Stack 2.3.1 - using `HACKAGE_USERNAME` and `HACKAGE_PASSWORD` environment variables - but it's [buggy](https://github.com/commercialhaskell/stack/issues/5290).