### PR TITLE
Add specialised main functions for event types

### DIFF
--- a/src/AWSLambda/Events.hs
+++ b/src/AWSLambda/Events.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveGeneric   #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module AWSLambda.Events
@@ -9,7 +9,13 @@ module AWSLambda.Events
   , module AWSLambda.Events.S3Event
   , module AWSLambda.Events.SNSEvent
   , module AWSLambda.Events.SQSEvent
+  , snsInSqsMain
+  , s3InSnsInSqsMain
   ) where
+
+import           Control.Exception.Safe (MonadCatch)
+import           Control.Monad.IO.Class
+import           Data.Aeson (FromJSON(..))
 
 import           AWSLambda.Events.APIGateway
 import           AWSLambda.Events.KinesisEvent
@@ -18,3 +24,9 @@ import           AWSLambda.Events.Records
 import           AWSLambda.Events.S3Event
 import           AWSLambda.Events.SNSEvent
 import           AWSLambda.Events.SQSEvent
+
+snsInSqsMain :: (FromJSON a, MonadCatch m, MonadIO m) => (a -> m ()) -> m ()
+snsInSqsMain = sqsMain . traverseSns
+
+s3InSnsInSqsMain :: (MonadCatch m, MonadIO m) => (S3EventNotification -> m ()) -> m ()
+s3InSnsInSqsMain = snsInSqsMain . traverseRecords

--- a/src/AWSLambda/Events.hs
+++ b/src/AWSLambda/Events.hs
@@ -25,8 +25,13 @@ import           AWSLambda.Events.S3Event
 import           AWSLambda.Events.SNSEvent
 import           AWSLambda.Events.SQSEvent
 
+-- | A specialised version of the 'lambdaMain' entry-point
+-- for handling individual SNS messages embedded in SQS messages
 snsInSqsMain :: (FromJSON a, MonadCatch m, MonadIO m) => (a -> m ()) -> m ()
 snsInSqsMain = sqsMain . traverseSns
 
+-- | A specialised version of the 'lambdaMain' entry-point
+-- for handling individual S3 event notifications embedded in
+-- SNS messages embedded in SQS messages
 s3InSnsInSqsMain :: (MonadCatch m, MonadIO m) => (S3EventNotification -> m ()) -> m ()
 s3InSnsInSqsMain = snsInSqsMain . traverseRecords

--- a/src/AWSLambda/Events/Records.hs
+++ b/src/AWSLambda/Events/Records.hs
@@ -1,14 +1,27 @@
+{-# LANGUAGE DeriveFoldable #-}
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module AWSLambda.Events.Records where
 
+import           Control.Exception.Safe (MonadCatch)
 import           Control.Lens.TH (makeLenses)
-import           Data.Aeson      (FromJSON (..), withObject, (.:))
+import           Control.Monad.IO.Class
+import           Data.Aeson (FromJSON(..), withObject, (.:))
+import           Data.Foldable (traverse_)
 
-newtype RecordsEvent a = RecordsEvent { _reRecords :: [a] } deriving (Eq, Show)
+import           AWSLambda.Handler (lambdaMain)
+
+newtype RecordsEvent a = RecordsEvent { _reRecords :: [a] } deriving (Eq, Show, Functor, Foldable)
 
 instance FromJSON a => FromJSON (RecordsEvent a) where
   parseJSON = withObject "RecordsEvent" $ \o -> RecordsEvent <$> o .: "Records"
 
 $(makeLenses ''RecordsEvent)
+
+traverseRecords :: Applicative m => (a -> m ()) -> RecordsEvent a -> m ()
+traverseRecords = traverse_
+
+recordsMain :: (FromJSON a, MonadCatch m, MonadIO m) => (a -> m ()) -> m ()
+recordsMain = lambdaMain . traverseRecords

--- a/src/AWSLambda/Events/Records.hs
+++ b/src/AWSLambda/Events/Records.hs
@@ -20,8 +20,11 @@ instance FromJSON a => FromJSON (RecordsEvent a) where
 
 $(makeLenses ''RecordsEvent)
 
+-- | Traverse all the records in a Lambda event
 traverseRecords :: Applicative m => (a -> m ()) -> RecordsEvent a -> m ()
 traverseRecords = traverse_
 
+-- | A specialised version of the 'lambdaMain' entry-point
+-- for handling individual records in a Lambda event
 recordsMain :: (FromJSON a, MonadCatch m, MonadIO m) => (a -> m ()) -> m ()
 recordsMain = lambdaMain . traverseRecords

--- a/src/AWSLambda/Events/SNSEvent.hs
+++ b/src/AWSLambda/Events/SNSEvent.hs
@@ -104,9 +104,12 @@ embedded = messages . unEmbed
 binary :: Traversal' (SNSEvent Base64) ByteString
 binary = messages . _Base64
 
+-- | Traverse all the messages in an SNS event
 traverseSns :: (FromJSON a, Applicative m) => (a -> m ()) -> SNSEvent (Embedded a) -> m ()
 traverseSns act = traverseRecords $ \record ->
     act $ record ^. srSns . smMessage . unTextValue . unEmbed
 
+-- | A specialed version of the 'lambdaMain' entry-point
+-- for handling individual SNS messages
 snsMain :: (FromJSON a, MonadCatch m, MonadIO m) => (a -> m ()) -> m ()
 snsMain = lambdaMain . traverseSns

--- a/src/AWSLambda/Events/SNSEvent.hs
+++ b/src/AWSLambda/Events/SNSEvent.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards   #-}
-{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 {-|
 Module: AWSLambda.Events.SNSEvent
@@ -11,23 +11,26 @@ Based on https://github.com/aws/aws-lambda-dotnet/tree/master/Libraries/src/Amaz
 -}
 module AWSLambda.Events.SNSEvent where
 
-import           Control.Applicative      ((<|>))
+import           Control.Applicative ((<|>))
+import           Control.Exception.Safe (MonadCatch)
 import           Control.Lens
-import           Data.Aeson               (FromJSON (..), genericParseJSON,
-                                           withObject, (.:), (.:?), (.!=))
-import           Data.Aeson.Casing        (aesonDrop, pascalCase)
+import           Control.Monad.IO.Class
+import           Data.Aeson
+                  (FromJSON(..), genericParseJSON, withObject, (.!=), (.:), (.:?))
+import           Data.Aeson.Casing (aesonDrop, pascalCase)
 import           Data.Aeson.Embedded
 import           Data.Aeson.TextValue
-import           Data.ByteString          (ByteString)
-import           Data.HashMap.Strict      (HashMap)
-import           Data.Text                (Text)
-import           Data.Time.Clock          (UTCTime)
-import           GHC.Generics             (Generic)
+import           Data.ByteString (ByteString)
+import           Data.HashMap.Strict (HashMap)
+import           Data.Text (Text)
+import           Data.Time.Clock (UTCTime)
+import           GHC.Generics (Generic)
 import           Network.AWS.Data.Base64
-import           Network.AWS.Data.Text    (FromText)
+import           Network.AWS.Data.Text (FromText)
 
 import           AWSLambda.Events.MessageAttribute
 import           AWSLambda.Events.Records
+import           AWSLambda.Handler (lambdaMain)
 
 data SNSMessage message = SNSMessage
   { _smMessage           :: !(TextValue message )
@@ -100,3 +103,10 @@ embedded = messages . unEmbed
 
 binary :: Traversal' (SNSEvent Base64) ByteString
 binary = messages . _Base64
+
+traverseSns :: (FromJSON a, Applicative m) => (a -> m ()) -> SNSEvent (Embedded a) -> m ()
+traverseSns act = traverseRecords $ \record ->
+    act $ record ^. srSns . smMessage . unTextValue . unEmbed
+
+snsMain :: (FromJSON a, MonadCatch m, MonadIO m) => (a -> m ()) -> m ()
+snsMain = lambdaMain . traverseSns

--- a/src/AWSLambda/Events/SQSEvent.hs
+++ b/src/AWSLambda/Events/SQSEvent.hs
@@ -58,9 +58,12 @@ sqsEmbedded = sqsMessages . unEmbed
 sqsBinary :: Traversal' (SQSEvent Base64) ByteString
 sqsBinary = sqsMessages . _Base64
 
+-- | Traverse all the messages in an SQS event
 traverseSqs :: (FromJSON a, Applicative m) => (a -> m ()) -> SQSEvent (Embedded a) -> m ()
 traverseSqs act = traverseRecords $ \record ->
     act $ record ^. sqsmBody . unTextValue . unEmbed
 
+-- | A specialised version of the 'lambdaMain' entry-point
+-- for handling individual SQS messages
 sqsMain :: (FromJSON a, MonadCatch m, MonadIO m) => (a -> m ()) -> m ()
 sqsMain = lambdaMain . traverseSqs


### PR DESCRIPTION
These specialised main functions make working with SQS, SNS and S3 events much simpler. This probably deserves some examples in the README (which currently doesn't mention these event types), but I'll do that separately.