### PR TITLE
Fix for SNS messages embedded in SQS

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,8 @@ For the changes in v0.6.x, see this file on the corresponding branch.
 
 ## Unreleased changes
 
+* Fix for traversing SNS messages embedded in SQS events.
+
 ## 0.12.0
 
 * Remove `LambdaEvent` type and unimplemented event types.

--- a/package.yaml
+++ b/package.yaml
@@ -42,3 +42,4 @@ tests:
       - hspec
       - hspec-discover
       - raw-strings-qq
+      - transformers

--- a/src/AWSLambda/Events.hs
+++ b/src/AWSLambda/Events.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveGeneric   #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module AWSLambda.Events
@@ -9,13 +9,15 @@ module AWSLambda.Events
   , module AWSLambda.Events.S3Event
   , module AWSLambda.Events.SNSEvent
   , module AWSLambda.Events.SQSEvent
+  , traverseSnsInSqs
   , snsInSqsMain
+  , traverseS3InSnsInSqs
   , s3InSnsInSqsMain
   ) where
 
-import           Control.Exception.Safe (MonadCatch)
+import           Control.Exception.Safe            (MonadCatch)
 import           Control.Monad.IO.Class
-import           Data.Aeson (FromJSON(..))
+import           Data.Aeson                        (FromJSON (..))
 
 import           AWSLambda.Events.APIGateway
 import           AWSLambda.Events.KinesisEvent
@@ -24,14 +26,24 @@ import           AWSLambda.Events.Records
 import           AWSLambda.Events.S3Event
 import           AWSLambda.Events.SNSEvent
 import           AWSLambda.Events.SQSEvent
+import           AWSLambda.Handler                 (lambdaMain)
+import           Data.Aeson.Embedded               (Embedded)
+
+-- | Traverse all the SNS messages embedded in an SQS event
+traverseSnsInSqs :: (FromJSON a, Applicative m) => (a -> m ()) -> SQSEvent (Embedded (SNSMessage (Embedded a))) -> m ()
+traverseSnsInSqs = traverseSqs . traverseSnsMessage
 
 -- | A specialised version of the 'lambdaMain' entry-point
--- for handling individual SNS messages embedded in SQS messages
+-- for handling individual SNS messages embedded in an SQS event
 snsInSqsMain :: (FromJSON a, MonadCatch m, MonadIO m) => (a -> m ()) -> m ()
-snsInSqsMain = sqsMain . traverseSns
+snsInSqsMain = lambdaMain . traverseSnsInSqs
+
+-- | Traverse S3 events embedded within SNS messages within an SQS event
+traverseS3InSnsInSqs :: (Applicative m) => (S3EventNotification -> m ()) -> SQSEvent (Embedded (SNSMessage (Embedded S3Event))) -> m ()
+traverseS3InSnsInSqs = traverseSnsInSqs . traverseRecords
 
 -- | A specialised version of the 'lambdaMain' entry-point
 -- for handling individual S3 event notifications embedded in
--- SNS messages embedded in SQS messages
+-- SNS messages embedded in an SQS event
 s3InSnsInSqsMain :: (MonadCatch m, MonadIO m) => (S3EventNotification -> m ()) -> m ()
-s3InSnsInSqsMain = snsInSqsMain . traverseRecords
+s3InSnsInSqsMain = lambdaMain . traverseS3InSnsInSqs

--- a/src/AWSLambda/Events/SNSEvent.hs
+++ b/src/AWSLambda/Events/SNSEvent.hs
@@ -104,6 +104,11 @@ embedded = messages . unEmbed
 binary :: Traversal' (SNSEvent Base64) ByteString
 binary = messages . _Base64
 
+-- | Traverse an SNS message
+traverseSnsMessage :: (FromJSON a, Applicative m) => (a -> m ()) -> SNSMessage (Embedded a) -> m ()
+traverseSnsMessage act message =
+    act $ message ^. smMessage . unTextValue . unEmbed
+
 -- | Traverse all the messages in an SNS event
 traverseSns :: (FromJSON a, Applicative m) => (a -> m ()) -> SNSEvent (Embedded a) -> m ()
 traverseSns act = traverseRecords $ \record ->


### PR DESCRIPTION
Turns out there was a bug in the traversal of SNS messages contained within an SQS event. Each record in the SQS event contains only one SNS messages, not a sequence of message records. I've fixed this and added a test.