### PR TITLE
Update resolver in hsfiles

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,6 +16,7 @@ jobs:
     strategy:
       matrix:
         resolver:
+          - lts-16
           - lts-15
           - lts-14
           - lts-13

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ In either case, you will want to have [Serverless] installed, eg. `npm install -
   stack new mypackage
   ```
 
-  LTS 9-15 are supported, older versions are likely to work too but untested.
+  LTS 9-16 are supported, older versions are likely to work too but untested.
 
 * Initialise a Serverless project inside the Stack package directory and install
   the `serverless-haskell` plugin:

--- a/bumpversion
+++ b/bumpversion
@@ -96,12 +96,15 @@ sedi -E '/^## Unreleased changes/{G;a\
 ## '$NEW_VERSION'
 }' ChangeLog.md
 
+latest_lts=$(./latest-lts lts)
+
 # bump version
 sedi -E 's/(version: +)"'$OLD_VERSION'"/\1"'$NEW_VERSION'"/g' package.yaml
 sedi -E 's/^  "version": "'$OLD_VERSION'"/  "version": "'$NEW_VERSION'"/g' package.json
 sedi -E 's/^  "version": "'$OLD_VERSION'"/  "version": "'$NEW_VERSION'"/g' package-lock.json
 sedi -E 's/^    "serverless-haskell": "\^'$OLD_VERSION'"/    "serverless-haskell": "^'$NEW_VERSION'"/g' serverless-haskell.hsfiles
 sedi -E 's/^- serverless-haskell-'$OLD_VERSION'/- serverless-haskell-'$NEW_VERSION'/g' serverless-haskell.hsfiles
+sedi -E 's/^resolver: lts-[0-9]+\.[0-9]+/resolver: '$latest_lts'/g' serverless-haskell.hsfiles
 
 
 if [ -z $DRY_RUN ]

--- a/bumpversion
+++ b/bumpversion
@@ -96,15 +96,12 @@ sedi -E '/^## Unreleased changes/{G;a\
 ## '$NEW_VERSION'
 }' ChangeLog.md
 
-latest_lts=$(./latest-lts lts)
-
 # bump version
 sedi -E 's/(version: +)"'$OLD_VERSION'"/\1"'$NEW_VERSION'"/g' package.yaml
 sedi -E 's/^  "version": "'$OLD_VERSION'"/  "version": "'$NEW_VERSION'"/g' package.json
 sedi -E 's/^  "version": "'$OLD_VERSION'"/  "version": "'$NEW_VERSION'"/g' package-lock.json
 sedi -E 's/^    "serverless-haskell": "\^'$OLD_VERSION'"/    "serverless-haskell": "^'$NEW_VERSION'"/g' serverless-haskell.hsfiles
 sedi -E 's/^- serverless-haskell-'$OLD_VERSION'/- serverless-haskell-'$NEW_VERSION'/g' serverless-haskell.hsfiles
-sedi -E 's/^resolver: lts-[0-9]+\.[0-9]+/resolver: '$latest_lts'/g' serverless-haskell.hsfiles
 
 
 if [ -z $DRY_RUN ]

--- a/serverless-haskell.hsfiles
+++ b/serverless-haskell.hsfiles
@@ -190,7 +190,7 @@ plugins:
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-12.19
+resolver: lts-16.3
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-15.11
+resolver: lts-16.3
 packages:
 - .
 - example-project

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 494638
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/15/11.yaml
-    sha256: 5747328cdcbb8fe9c96fc048b5566167c80dd176a41b52d3b363058e3cc1dc5d
-  original: lts-15.11
+    size: 531696
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/3.yaml
+    sha256: 65e3a94c65ad07fa1913649e3f1e36c4af51bf528a5d9fd217bdc1b46d0477cc
+  original: lts-16.3

--- a/update-lts
+++ b/update-lts
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Update stack.yaml and serverless-haskell.hsfiles to the latest lts
+
+set -ex
+
+sedi() {
+    if [ "$(uname)" = "Linux" ]
+    then
+        sed -i "$@"
+    else
+        sed -i '' "$@"
+    fi
+}
+
+latest_lts=$(./latest-lts lts)
+
+sedi -E 's/^resolver: lts-[0-9]+\.[0-9]+/resolver: '$latest_lts'/g' stack.yaml
+sedi -E 's/^resolver: lts-[0-9]+\.[0-9]+/resolver: '$latest_lts'/g' serverless-haskell.hsfiles


### PR DESCRIPTION
Updates resolver in `serverless-haskell.hsfiles` to latest LTS (16.3) and modifies `bumpversion` to keep this up-to-date.