### PR TITLE
Use new lambdaHashingVersion

### DIFF
--- a/integration-test/skeleton/serverless.yml
+++ b/integration-test/skeleton/serverless.yml
@@ -5,6 +5,7 @@ configValidationMode: error
 provider:
   name: aws
   runtime: haskell
+  lambdaHashingVersion: 20201221
   apiGateway:
     shouldStartNameWithService: true
 


### PR DESCRIPTION
Remove deprecation warning about the new hashing version from integration test output 
