### PR TITLE
Update readme for clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Hackage dependencies](https://img.shields.io/hackage-deps/v/serverless-haskell.svg)](https://packdeps.haskellers.com/feed?needle=serverless-haskell)
 [![npm](https://img.shields.io/npm/v/serverless-haskell.svg)](https://www.npmjs.com/package/serverless-haskell)
 
-Deploying Haskell code onto [AWS Lambda] using [Serverless].
+Deploying Haskell code onto [AWS Lambda] as native runtime using [Serverless].
 
 ## Prerequisites
 


### PR DESCRIPTION
Added a bit of clarification so that people don't get turned off by reading this top google search result right away: https://www.haskelltutorials.com/haskell-aws-lambda/avoid-serverless-haskell.html
